### PR TITLE
Remove MySQL and replace phpMyAdmin with phpLiteAdmin in docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -86,48 +86,58 @@ services:
     depends_on:
       - cb-restapigw
       - cb-spider
-      - cb-tumblebug-mysql
+#     - cb-tumblebug-mysql
     volumes:
       - ./data/cb-tumblebug/meta_db:/app/meta_db/dat
 #     - ./data/cb-tumblebug/log:/app/log
     environment:
       - SPIDER_URL=http://cb-restapigw:8000/spider
-      - DB_URL=cb-tumblebug-mysql:3306
-      - DB_DATABASE=cb_tumblebug
-      - DB_USER=cb_tumblebug
-      - DB_PASSWORD=cb_tumblebug
+#     - DB_URL=cb-tumblebug-mysql:3306
+#     - DB_DATABASE=cb_tumblebug
+#     - DB_USER=cb_tumblebug
+#     - DB_PASSWORD=cb_tumblebug
 
-  cb-tumblebug-mysql:
-    image: mysql
-    container_name: cb-tumblebug-mysql
+# cb-tumblebug-mysql:
+#   image: mysql
+#   container_name: cb-tumblebug-mysql
+#   ports:
+#     - "3306:3306" # 접근 포트 설정 (컨테이너 외부:컨테이너 내부)
+#   environment: # -e 옵션
+#     MYSQL_ROOT_PASSWORD: "cloud-barista"  # MYSQL 패스워드 설정 옵션
+#     MYSQL_DATABASE: cb_tumblebug
+#     MYSQL_USER: cb_tumblebug
+#     MYSQL_PASSWORD: cb_tumblebug
+#   command: # 명령어 실행
+#     - --character-set-server=utf8mb4
+#     - --collation-server=utf8mb4_unicode_ci
+#     - --default-authentication-plugin=mysql_native_password
+#   volumes:
+#     - ./data/cb-tumblebug-mysql:/var/lib/mysql
+
+# cb-phpmyadmin:
+#   image: phpmyadmin/phpmyadmin
+#   container_name: cb-phpmyadmin
+#   ports:
+#     - 80:80
+#   environment: # -e 옵션
+#     PMA_HOSTS: cb-tumblebug-mysql
+#     PMA_PORTS: 3306
+#     PMA_USER: cb_tumblebug
+#     PMA_PASSWORD: cb_tumblebug
+#   links:
+#     - cb-tumblebug-mysql
+#   depends_on:
+#     - cb-tumblebug-mysql
+
+  cb-tumblebug-phpliteadmin:
+    image: acttaiwan/phpliteadmin
+#   image: jihoons/phpliteadmin
+    container_name: cb-tumblebug-phpliteadmin
     ports:
-      - "3306:3306" # 접근 포트 설정 (컨테이너 외부:컨테이너 내부)
-    environment: # -e 옵션
-      MYSQL_ROOT_PASSWORD: "cloud-barista"  # MYSQL 패스워드 설정 옵션
-      MYSQL_DATABASE: cb_tumblebug
-      MYSQL_USER: cb_tumblebug
-      MYSQL_PASSWORD: cb_tumblebug
-    command: # 명령어 실행
-      - --character-set-server=utf8mb4
-      - --collation-server=utf8mb4_unicode_ci
-      - --default-authentication-plugin=mysql_native_password
+      - 2015:2015
     volumes:
-      - ./data/cb-tumblebug-mysql:/var/lib/mysql
+      - ./data/cb-tumblebug/meta_db:/db
 
-  cb-phpmyadmin:
-    image: phpmyadmin/phpmyadmin
-    container_name: cb-phpmyadmin
-    ports:
-      - 80:80
-    environment: # -e 옵션
-      PMA_HOSTS: cb-tumblebug-mysql
-      PMA_PORTS: 3306
-      PMA_USER: cb_tumblebug
-      PMA_PASSWORD: cb_tumblebug
-    links:
-      - cb-tumblebug-mysql
-    depends_on:
-      - cb-tumblebug-mysql
 
   # CB-Dragonfly
   cb-dragonfly:


### PR DESCRIPTION
[phpLiteAdmin]
- Provides control for all SQL files in `./data/cb-tumblebug/meta_db`
- Endpoint: http://{host}:2015/phpliteadmin.php
- Default password: `admin` (set in the Docker image `acttaiwan/phpliteadmin`)