### PR TITLE
Add mode-selection feature

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -33,8 +33,8 @@ func scanAndWriteMode() {
 
 	fmt.Println("")
 	fmt.Println("[Options]")
-	fmt.Println("1: Single-node version (Docker Compose based)")
-	fmt.Println("2: K8s-cluster version (requires a K8s cluster with Helm 3 enabled)")
+	fmt.Println("1: Docker Compose environment (Requires Docker and Docker Compose)")
+	fmt.Println("2: Kubernetes environment (Requires Kubernetes cluster with Helm 3)")
 	fmt.Println("")
 	fmt.Print("Choose 1 or 2: ")
 
@@ -45,11 +45,11 @@ func scanAndWriteMode() {
 
 	switch userInput {
 	case 1:
-		fmt.Println("[1: Single-node version (Docker Compose based)] selected.")
-		tempStr = "singlenode"
+		fmt.Println("[1: Docker Compose environment (Requires Docker and Docker Compose)] selected.")
+		tempStr = "DockerCompose"
 	case 2:
-		fmt.Println("[2: K8s-cluster version (requires a K8s cluster with Helm 3 enabled)] selected.")
-		tempStr = "k8scluster"
+		fmt.Println("[2: Kubernetes environment (Requires Kubernetes cluster with Helm 3)] selected.")
+		tempStr = "Kubernetes"
 	default:
 		fmt.Println("You should choose between 1 and 2.")
 		return
@@ -72,7 +72,7 @@ func readMode() string {
 		CB_OPERATOR_MODE = string(data)
 		fmt.Println("CB_OPERATOR_MODE: " + CB_OPERATOR_MODE)
 
-		//if CB_OPERATOR_MODE == "singlenode" || CB_OPERATOR_MODE == "k8scluster" {
+		//if CB_OPERATOR_MODE == "DockerCompose" || CB_OPERATOR_MODE == "Kubernetes" {
 		return CB_OPERATOR_MODE
 		//}
 
@@ -100,13 +100,13 @@ func main() {
 
 	mode := readMode()
 
-	if mode == "singlenode" {
+	if mode == "DockerCompose" {
 		cmd.Execute()
-	} else if mode == "k8scluster" {
+	} else if mode == "Kubernetes" {
 
 	} else {
 		fmt.Println("Invalid CB_OPERATOR_MODE: " + mode)
-		fmt.Println("CB_OPERATOR_MODE should be one of these: singlenode, k8scluster")
+		fmt.Println("CB_OPERATOR_MODE should be one of these: DockerCompose, Kubernetes")
 
 		//fmt.Println("To change CB_OPERATOR_MODE, just delete the CB_OPERATOR_MODE file and re-run the cb-operator.")
 		scanAndWriteMode()

--- a/src/main.go
+++ b/src/main.go
@@ -15,8 +15,92 @@ limitations under the License.
 */
 package main
 
-import "github.com/cloud-barista/cb-operator/src/cmd"
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/cloud-barista/cb-operator/src/cmd"
+)
+
+func errCheck(e error) {
+	if e != nil {
+		panic(e)
+	}
+}
+
+func scanAndWriteMode() {
+
+	fmt.Println("")
+	fmt.Println("[Options]")
+	fmt.Println("1: Single-node version (Docker Compose based)")
+	fmt.Println("2: K8s-cluster version (requires a K8s cluster with Helm 3 enabled)")
+	fmt.Println("")
+	fmt.Print("Choose 1 or 2: ")
+
+	var userInput uint8
+	fmt.Scanf("%d", &userInput)
+
+	var tempStr string
+
+	switch userInput {
+	case 1:
+		fmt.Println("[1: Single-node version (Docker Compose based)] selected.")
+		tempStr = "singlenode"
+	case 2:
+		fmt.Println("[2: K8s-cluster version (requires a K8s cluster with Helm 3 enabled)] selected.")
+		tempStr = "k8scluster"
+	default:
+		fmt.Println("You should choose between 1 and 2.")
+		return
+	}
+
+	err := ioutil.WriteFile("./CB_OPERATOR_MODE", []byte(tempStr), os.FileMode(644))
+	errCheck(err)
+
+	fmt.Println("")
+	fmt.Println("CB_OPERATOR_MODE is set to: " + tempStr)
+	fmt.Println("To change CB_OPERATOR_MODE, just delete the CB_OPERATOR_MODE file and re-run the cb-operator.")
+}
+
+func readMode() string {
+	if _, err := os.Stat("./CB_OPERATOR_MODE"); err == nil {
+		// if file exists
+		data, err := ioutil.ReadFile("./CB_OPERATOR_MODE")
+		errCheck(err)
+
+		CB_OPERATOR_MODE = string(data)
+		fmt.Println("CB_OPERATOR_MODE: " + CB_OPERATOR_MODE)
+
+		if CB_OPERATOR_MODE == "singlenode" || CB_OPERATOR_MODE == "k8scluster" {
+			return CB_OPERATOR_MODE
+		}
+
+	} else if os.IsNotExist(err) == true {
+		// path/to/whatever does *not* exist
+		fmt.Println("CB_OPERATOR_MODE file does not exist.")
+		scanAndWriteMode()
+		result := readMode()
+		return result
+
+	} else {
+		// Schrodinger: file may or may not exist. See err for details.
+
+		// Therefore, do *NOT* use !os.IsNotExist(err) to test for file existence
+
+		errCheck(err)
+		return ""
+	}
+	return ""
+}
+
+var CB_OPERATOR_MODE string
 
 func main() {
-  cmd.Execute()
+
+	mode := readMode()
+
+	if mode == "singlenode" {
+		cmd.Execute()
+	}
 }

--- a/src/main.go
+++ b/src/main.go
@@ -72,9 +72,9 @@ func readMode() string {
 		CB_OPERATOR_MODE = string(data)
 		fmt.Println("CB_OPERATOR_MODE: " + CB_OPERATOR_MODE)
 
-		if CB_OPERATOR_MODE == "singlenode" || CB_OPERATOR_MODE == "k8scluster" {
-			return CB_OPERATOR_MODE
-		}
+		//if CB_OPERATOR_MODE == "singlenode" || CB_OPERATOR_MODE == "k8scluster" {
+		return CB_OPERATOR_MODE
+		//}
 
 	} else if os.IsNotExist(err) == true {
 		// path/to/whatever does *not* exist
@@ -102,5 +102,14 @@ func main() {
 
 	if mode == "singlenode" {
 		cmd.Execute()
+	} else if mode == "k8scluster" {
+
+	} else {
+		fmt.Println("Invalid CB_OPERATOR_MODE: " + mode)
+		fmt.Println("CB_OPERATOR_MODE should be one of these: singlenode, k8scluster")
+
+		//fmt.Println("To change CB_OPERATOR_MODE, just delete the CB_OPERATOR_MODE file and re-run the cb-operator.")
+		scanAndWriteMode()
+		main()
 	}
 }


### PR DESCRIPTION
Related PR: #38 (which is discarded)

[Workflow]
1. User builds and executes `./operator`
2. `operator` checks if the file `./CB_OPERATOR_MODE` exists
   - If exists:
     - If `CB_OPERATOR_MODE` == `singlenode` → Docker Compose based
     - If `CB_OPERATOR_MODE` == `k8scluster` → K8s + Helm based (To-be-developed feature)
   - If not exists, or other than `singlenode` or `k8scluster`:
     - Scanf
     - `1`  → Set `CB_OPERATOR_MODE` to `singlenode` and continue
     - `2`  → Set `CB_OPERATOR_MODE` to `k8scluster` and continue
     - Other than `1` or `2` → Scanf again

```
❯ ./operator     
CB_OPERATOR_MODE file does not exist.

[Options]
1: Single-node version (Docker Compose based)
2: K8s-cluster version (requires a K8s cluster with Helm 3 enabled)

Choose 1 or 2: 3
You should choose between 1 and 2.
CB_OPERATOR_MODE file does not exist.

[Options]
1: Single-node version (Docker Compose based)
2: K8s-cluster version (requires a K8s cluster with Helm 3 enabled)

Choose 1 or 2: 4
You should choose between 1 and 2.
CB_OPERATOR_MODE file does not exist.

[Options]
1: Single-node version (Docker Compose based)
2: K8s-cluster version (requires a K8s cluster with Helm 3 enabled)

CB_OPERATOR_MODE file does not exist.

[Options]

Choose 1 or 2: 1
[1: Single-node version (Docker Compose based)] selected.

CB_OPERATOR_MODE is set to: singlenode
To change CB_OPERATOR_MODE, just delete the CB_OPERATOR_MODE file and re-run the cb-operator.
CB_OPERATOR_MODE: singlenode
The operator is a tool to operate Cloud-Barista system. 
  
  For example, you can setup and run, stop, and ... Cloud-Barista runtimes.
  
  - ./operator pull [-f ../docker-compose.yaml]
  - ./operator exec -t cb-tumblebug -c "ls -al"
  - ./operator stop [-f ../docker-compose.yaml]
  - ./operator remove [-f ../docker-compose.yaml] -v -i
Available Commands:
  exec        Run commands in a target component of Cloud-Barista System
  help        Help about any command
  info        Get information of Cloud-Barista System
  pull        Pull images of Cloud-Barista System containers
  remove      Stop and Remove Cloud-Barista System
  run         Setup and Run Cloud-Barista System
  stop        Stop Cloud-Barista System

Flags:
      --config string   config file (default is $HOME/.operator.yaml)
  -h, --help            help for operator
  -t, --toggle          Help message for toggle

Use "operator [command] --help" for more information about a command.
```