### PR TITLE
Change CB-Dragonfly's etcd version from 3.4.9 to 3.3.11

### DIFF
--- a/helm-chart/install/kubernetes/values.yaml
+++ b/helm-chart/install/kubernetes/values.yaml
@@ -3,6 +3,9 @@ cb-dragonfly:
   service:
     nodePort: 30090
     type: NodePort
+  etcd:
+    image:
+      tag: 3.3.11
 
 cb-restapigw:
   enabled : true


### PR DESCRIPTION
[유의사항]
기존에 이 Helm chart 로 Cloud-Barista 를 실행했던 적이 있는 컴퓨터 또는 K8s 클러스터에서는
이전에 `cb-dragonfly-etcd` 파드가 실행되면서 생성된 PV/PVC 를 삭제해야
새로 실행하는 `cb-dragonfly-etcd` 파드가 정상적으로 동작합니다.

---

[원인 1]
- 이전에 etcd 3.4.9 가 실행되면서, PV+PVC가 생성되었고, etcd 3.4.9 가 여기에 내용을 기록했음
- 이후 etcd 버전을 3.3.11 로 바꿔서 실행하면, PV 의 내용을 읽어보는데, etcd 3.4 를 실행했을 때의 내용이 남아 있어서 에러 메시지를 출력하고 실행이 되지 않음

`kubectl logs cb-dragonfly-etcd-0 -n cloud-barista`
```
2020-07-30 06:33:10.549626 I | etcdserver: starting server... [version: 3.3.11, cluster version: to_be_decided]
2020-07-30 06:33:10.550567 I | etcdserver/membership: added member 2b96115f7d46bf19 [http://cb-dragonfly-etcd-0.cb-dragonfly-etcd-headless.cloud-barista.svc.cluster.local:2380] to cluster b1611160df1a5228
2020-07-30 06:33:10.550789 N | etcdserver/membership: set the initial cluster version to 3.4
2020-07-30 06:33:10.550806 C | etcdserver/membership: cluster cannot be downgraded (current version: 3.3.11 is lower than determined cluster version: 3.4).
```

[원인 2]
- Helm 2 에는 `helm delete --purge` 라는 명령이 있었는데, Helm 3 에서는 delete 가 uninstall 로 이름만 바뀌었고, `--purge` 옵션이 기본값으로 설정됨
- `cb-restapigw-influxdb`, `cb-dragonfly-influxdb`, `docker-registry` 도 실행 시 PV+PVC를 생성하는데, `helm uninstall` 시 함께 삭제됨
- `cb-dragonfly-etcd-0` 이 실행되면서 생성된 PV+PVC 는 `helm uninstall` 시 삭제되지 않았음

---

[`helm uninstall` 실행 전]

`kubectl get pv`
```
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                    STORAGECLASS   REASON   AGE
pvc-125eea47-4c82-4f34-9ad8-ffb4cc65aec7   8Gi        RWO            Delete           Bound    cloud-barista/cb-dragonfly-influxdb      standard                31m
pvc-33c0c05b-fffa-4c9d-9b14-b765ba165f17   8Gi        RWO            Delete           Bound    cloud-barista/cb-restapigw-influxdb      standard                31m
pvc-3dd2886d-e166-4f9e-b63b-46702b2aee50   1Gi        RWO            Delete           Bound    cloud-barista/docker-registry            standard                31m
pvc-64906547-3abf-4c51-b703-dc4be4a4b779   8Gi        RWO            Delete           Bound    cloud-barista/data-cb-dragonfly-etcd-0   standard                31m
```

`kubectl get pvc -n cloud-barista`
```
NAME                       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
cb-dragonfly-influxdb      Bound    pvc-125eea47-4c82-4f34-9ad8-ffb4cc65aec7   8Gi        RWO            standard       32m
cb-restapigw-influxdb      Bound    pvc-33c0c05b-fffa-4c9d-9b14-b765ba165f17   8Gi        RWO            standard       32m
data-cb-dragonfly-etcd-0   Bound    pvc-64906547-3abf-4c51-b703-dc4be4a4b779   8Gi        RWO            standard       32m
docker-registry            Bound    pvc-3dd2886d-e166-4f9e-b63b-46702b2aee50   1Gi        RWO            standard       32m
```

[`helm uninstall` 실행 후]

`kubectl get pv`
```
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                    STORAGECLASS   REASON   AGE
pvc-64906547-3abf-4c51-b703-dc4be4a4b779   8Gi        RWO            Delete           Bound    cloud-barista/data-cb-dragonfly-etcd-0   standard                35m
```

`kubectl get pvc -n cloud-barista`
```
NAME                       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
data-cb-dragonfly-etcd-0   Bound    pvc-64906547-3abf-4c51-b703-dc4be4a4b779   8Gi        RWO            standard       36m
```

---

[`cb-dragonfly-etcd-0` 의 PV/PVC 만 삭제되지 않는 이유에 대한 추정]
- `helm.sh/resource-policy: "keep"` 같은 것이 etcd chart에 기재되어 있다. (https://github.com/helm/helm/issues/6261)
- StatefulSets' dynamic storage provisioning 으로 만들어진 PVC는 `helm uninstall` 해도 삭제되지 않음 (https://github.com/helm/helm/issues/3313)
- reclaimPolicy 가 Delete 가 아니라 Retain 이면 그럴 수 있음 (https://github.com/goharbor/harbor-helm/issues/268) (그런데 위를 보면 Delete 로 되어 있어서, 이 문제는 아님)

[추후 Cloud-Barista 의 구성요소들에게 persistency/statefulness 를 주기 위한 방안들 (helm uninstall 해도 PV 삭제되지 않게..)]
- `"helm.sh/resource-policy": {{ default "keep" .Values.resourcePolicy }}` 같은 것을 기재한다. (https://github.com/helm/helm/issues/1875)
- StatefulSets' dynamic storage provisioning 을 활용한다.
- reclaimPolicy 를 Retain 등으로 설정한다.


---

Ref: @itnpeople