### PR TITLE
Add PVC for CB-Spider and CB-Tumblebug

### DIFF
--- a/helm-chart/install/kubernetes/charts/cb-spider/templates/deployment.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-spider/templates/deployment.yaml
@@ -43,6 +43,13 @@ spec:
           #     port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+          - name: {{ template "cb-spider.fullname" . }}
+            mountPath: /root/go/src/github.com/cloud-barista/cb-spider/meta_db
+      volumes:
+      - name: {{ template "cb-spider.fullname" . }} #cb-spider-persistent-storage
+        persistentVolumeClaim:
+          claimName: {{ template "cb-spider.fullname" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/install/kubernetes/charts/cb-spider/templates/pvc.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-spider/templates/pvc.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.persistence.enabled }}
+{{- if not .Values.persistence.existingClaim -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  annotations:
+    "helm.sh/resource-policy": {{ default "keep" .Values.resourcePolicy }}
+  name: {{ template "cb-spider.fullname" . }}
+  labels:
+    app: {{ template "cb-spider.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/helm-chart/install/kubernetes/charts/cb-spider/values.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-spider/values.yaml
@@ -1,9 +1,5 @@
 replicaCount: 1
 
-env:
-  - name: "SPIDER_URL"
-    value: "http://cb-restapigw:8000/spider"
-
 image:
   repository: cloudbaristaorg/cb-spider
   pullPolicy: IfNotPresent
@@ -47,6 +43,12 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+persistence:
+  accessMode: 'ReadWriteMany'
+  enabled: false
+  size: 2Gi
+  # storageClass: '-'
 
 nodeSelector: {}
 

--- a/helm-chart/install/kubernetes/charts/cb-tumblebug/templates/deployment.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-tumblebug/templates/deployment.yaml
@@ -43,6 +43,13 @@ spec:
           #     port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+          - name: {{ template "cb-tumblebug.fullname" . }}
+            mountPath: /app/meta_db
+      volumes:
+      - name: {{ template "cb-tumblebug.fullname" . }} #cb-tumblebug-persistent-storage
+        persistentVolumeClaim:
+          claimName: {{ template "cb-tumblebug.fullname" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/install/kubernetes/charts/cb-tumblebug/templates/pvc.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-tumblebug/templates/pvc.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.persistence.enabled }}
+{{- if not .Values.persistence.existingClaim -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  annotations:
+    "helm.sh/resource-policy": {{ default "keep" .Values.resourcePolicy }}
+  name: {{ template "cb-tumblebug.fullname" . }}
+  labels:
+    app: {{ template "cb-tumblebug.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/helm-chart/install/kubernetes/charts/cb-tumblebug/values.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-tumblebug/values.yaml
@@ -52,6 +52,12 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+persistence:
+  accessMode: 'ReadWriteMany'
+  enabled: false
+  size: 2Gi
+  # storageClass: '-'
+
 nodeSelector: {}
 
 tolerations: []

--- a/helm-chart/install/kubernetes/values.yaml
+++ b/helm-chart/install/kubernetes/values.yaml
@@ -18,12 +18,18 @@ cb-spider:
   service:
     nodePort: 31024
     type: NodePort
+  persistence:
+    enabled: true
+    size: 1Gi
 
 cb-tumblebug:
   enabled : true
   service:
     nodePort: 31323
     type: NodePort
+  persistence:
+    enabled: true
+    size: 1Gi
 
 cb-webtool:
   enabled : true

--- a/src/cmd/remove.go
+++ b/src/cmd/remove.go
@@ -39,7 +39,17 @@ var removeCmd = &cobra.Command{
 			case common.Mode_Kubernetes:
 				cmdStr = "sudo helm uninstall --namespace " + common.CB_K8s_Namespace + " " + common.CB_Helm_Release_Name
 				common.SysCall(cmdStr)
-				fallthrough
+
+				cmdStr = "sudo kubectl delete pvc cb-spider -n " + common.CB_K8s_Namespace
+				common.SysCall(cmdStr)
+
+				cmdStr = "sudo kubectl delete pvc cb-tumblebug -n " + common.CB_K8s_Namespace
+				common.SysCall(cmdStr)
+
+				cmdStr = "sudo kubectl delete pvc data-cb-dragonfly-etcd-0 -n " + common.CB_K8s_Namespace
+				common.SysCall(cmdStr)
+
+				//fallthrough
 			case common.Mode_DockerCompose:
 				if volFlag && imgFlag {
 					cmdStr = "sudo docker-compose -f " + common.FileStr + " down -v --rmi all"


### PR DESCRIPTION
Tested with:
- `test/official/sequentialFullTest/testAll-mcis-mcir-ns-cloud.sh aws 1 jhseo`
- `test/official/sequentialFullTest/cleanAll-mcis-mcir-ns-cloud.sh aws 1 jhseo`
- Metadata of CB-Spider and CB-Tumblebug is preserved after `./operator stop` (`helm uninstall`) and `./operator run` (`helm install`)

---

| PV/PVC | Retain/Keep | Why "Yes"? |
|---|---|---|
| cb-spider | Yes | `"helm.sh/resource-policy": "keep"` |
| cb-tumblebug | Yes | `"helm.sh/resource-policy": "keep"` |
| data-cb-dragonfly-etcd-0 | Yes | PVC is generated through StatefulSets' dynamic volume provisioning. |
| cb-dragonfly-influxdb | No |   |
| cb-restapigw-influxdb | No |   |
| docker-registry | No |   |
|   |   |   |
|   |   |   |

---

[Below is For Your Information]

[When CB Helm chart is installed] (`./operator run`)
```
❯ kubectl get pv -n cloud-barista 
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                    STORAGECLASS   REASON   AGE
pvc-2a8a7815-9b8b-4be1-9cd1-4ffad8dbff16   1Gi        RWO            Delete           Bound    cloud-barista/docker-registry            standard                16m
pvc-2bedc82f-d948-443e-827c-bccfa746f135   8Gi        RWO            Delete           Bound    cloud-barista/data-cb-dragonfly-etcd-0   standard                17h
pvc-32485b45-a515-4146-b1bd-3a4b7db099e1   8Gi        RWO            Delete           Bound    cloud-barista/cb-dragonfly-influxdb      standard                16m
pvc-6ec3adda-ca32-4e13-9cd8-a5f361d9cda2   1Gi        RWX            Delete           Bound    cloud-barista/cb-tumblebug               standard                33m
pvc-cf999e6c-fd24-45c7-9921-8b1e9592f2be   8Gi        RWO            Delete           Bound    cloud-barista/cb-restapigw-influxdb      standard                16m
pvc-dac064d0-d51e-49ef-819b-dc3d0b363644   1Gi        RWX            Delete           Bound    cloud-barista/cb-spider                  standard                83m
```

```
❯ kubectl get pvc -n cloud-barista
NAME                       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
cb-dragonfly-influxdb      Bound    pvc-32485b45-a515-4146-b1bd-3a4b7db099e1   8Gi        RWO            standard       17m
cb-restapigw-influxdb      Bound    pvc-cf999e6c-fd24-45c7-9921-8b1e9592f2be   8Gi        RWO            standard       17m
cb-spider                  Bound    pvc-dac064d0-d51e-49ef-819b-dc3d0b363644   1Gi        RWX            standard       84m
cb-tumblebug               Bound    pvc-6ec3adda-ca32-4e13-9cd8-a5f361d9cda2   1Gi        RWX            standard       34m
data-cb-dragonfly-etcd-0   Bound    pvc-2bedc82f-d948-443e-827c-bccfa746f135   8Gi        RWO            standard       17h
docker-registry            Bound    pvc-2a8a7815-9b8b-4be1-9cd1-4ffad8dbff16   1Gi        RWO            standard       17m
```

---

[When CB Helm chart is uninstalled] (`./operator stop`)
```
❯ kubectl get pv -n cloud-barista 
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                    STORAGECLASS   REASON   AGE
pvc-2bedc82f-d948-443e-827c-bccfa746f135   8Gi        RWO            Delete           Bound    cloud-barista/data-cb-dragonfly-etcd-0   standard                17h
pvc-6ec3adda-ca32-4e13-9cd8-a5f361d9cda2   1Gi        RWX            Delete           Bound    cloud-barista/cb-tumblebug               standard                36m
pvc-dac064d0-d51e-49ef-819b-dc3d0b363644   1Gi        RWX            Delete           Bound    cloud-barista/cb-spider                  standard                86m
```

```
❯ kubectl get pvc -n cloud-barista
NAME                       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
cb-spider                  Bound    pvc-dac064d0-d51e-49ef-819b-dc3d0b363644   1Gi        RWX            standard       87m
cb-tumblebug               Bound    pvc-6ec3adda-ca32-4e13-9cd8-a5f361d9cda2   1Gi        RWX            standard       37m
data-cb-dragonfly-etcd-0   Bound    pvc-2bedc82f-d948-443e-827c-bccfa746f135   8Gi        RWO            standard       17h
```