### PR TITLE
Add Spider and TB's conf file to Helm chart

### DIFF
--- a/helm-chart/install/kubernetes/charts/cb-spider/files/conf/grpc_conf.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-spider/files/conf/grpc_conf.yaml
@@ -1,0 +1,18 @@
+version: 1
+grpc:
+  spidersrv:
+    addr: :50251
+    #reflection: enable
+    #tls:
+    #  tls_cert: $CBSPIDER_ROOT/certs/server.crt
+    #  tls_key: $CBSPIDER_ROOT/certs/server.key
+    interceptors:
+      #auth_jwt:
+      #  jwt_key: your_secret_key
+      prometheus_metrics:
+        listen_port: 9092
+      opentracing:
+        jaeger:
+          endpoint: localhost:6831
+          service_name: spider grpc server
+          sample_rate: 1

--- a/helm-chart/install/kubernetes/charts/cb-spider/files/conf/log_conf.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-spider/files/conf/log_conf.yaml
@@ -1,0 +1,18 @@
+#### Config for CB-Log Lib. ####
+
+cblog:
+  ## true | false
+  loopcheck: false # This temp method for development is busy wait. cf) cblogger.go:levelSetupLoop().
+
+  ## debug | info | warn | error
+  loglevel: info # If loopcheck is true, You can set this online.
+
+  ## true | false
+  logfile: true 
+
+## Config for File Output ##
+logfileinfo:
+  filename: ./log/cblogs.log
+  maxsize: 10 # megabytes
+  maxbackups: 50
+  maxage: 31 # days

--- a/helm-chart/install/kubernetes/charts/cb-spider/files/conf/store_conf.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-spider/files/conf/store_conf.yaml
@@ -1,0 +1,15 @@
+#### Config for CB-Store ####
+
+# server type: NUTSDB | ETCD
+# NUTSDB: embedded Key-Value Store on Local Filesystem
+storetype: NUTSDB
+#storetype: ETCD
+
+nutsdb:
+  dbpath: "$CBSTORE_ROOT/meta_db/dat"
+  segmentsize: 1048576  # 1048576 1024*1024 (1MB)
+  #segmentsize: 10485760  # 10485760 10*1024*1024 (10MB)
+
+etcd:
+  # etcd server, when ETCD typpe
+  etcdserverport: "cb-etcd:2379"

--- a/helm-chart/install/kubernetes/charts/cb-spider/templates/configmap.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-spider/templates/configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cb-spider.fullname" . }}-config
+  labels:
+    {{- include "cb-spider.labels" .  | nindent 4 }}
+data:
+  grpc_conf.yaml: |-
+    {{ range .Files.Lines "files/conf/grpc_conf.yaml" }}
+    {{ . }}
+    {{ end }}
+  log_conf.yaml: |-
+    {{ range .Files.Lines "files/conf/log_conf.yaml" }}
+    {{ . }}
+    {{ end }}
+  store_conf.yaml: |-
+    {{ range .Files.Lines "files/conf/store_conf.yaml" }}
+    {{ . }}
+    {{ end }}

--- a/helm-chart/install/kubernetes/charts/cb-spider/templates/deployment.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-spider/templates/deployment.yaml
@@ -46,10 +46,15 @@ spec:
           volumeMounts:
           - name: {{ template "cb-spider.fullname" . }}
             mountPath: /root/go/src/github.com/cloud-barista/cb-spider/meta_db
+          - name: config-volume
+            mountPath: {{ .Values.spider.rootPath }}/conf
       volumes:
       - name: {{ template "cb-spider.fullname" . }} #cb-spider-persistent-storage
         persistentVolumeClaim:
           claimName: {{ template "cb-spider.fullname" . }}
+      - name: config-volume
+        configMap:
+          name: {{ include "cb-spider.fullname" . }}-config
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/install/kubernetes/charts/cb-spider/values.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-spider/values.yaml
@@ -1,3 +1,6 @@
+spider:
+  rootPath: "/root/go/src/github.com/cloud-barista/cb-spider"
+
 replicaCount: 1
 
 image:

--- a/helm-chart/install/kubernetes/charts/cb-tumblebug/files/conf/grpc_conf.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-tumblebug/files/conf/grpc_conf.yaml
@@ -1,0 +1,32 @@
+version: 1
+grpc:
+  tumblebugsrv:
+    addr: :50252
+    #reflection: enable
+    #tls:
+    #  tls_cert: $CBTUMBLEBUG_ROOT/certs/server.crt
+    #  tls_key: $CBTUMBLEBUG_ROOT/certs/server.key
+    interceptors:
+      #auth_jwt:
+      #  jwt_key: your_secret_key
+      prometheus_metrics:
+        listen_port: 9093
+      opentracing:
+        jaeger:
+          endpoint: localhost:6832
+          service_name: tumblebug grpc server
+          sample_rate: 1  
+  spidersrv:
+    addr: cb-spider:50251
+  spidercli:
+    timeout: 90s
+    #tls:
+    #  tls_ca: $CBTUMBLEBUG_ROOT/certs/ca.crt
+    interceptors:
+      #auth_jwt:
+      #  jwt_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbGllbnRJUCI6IjEyNy4wLjAuMSIsImV4cGlyZSI6MTkwODMyNTY1OCwib3JnTmFtZSI6IkVUUkkiLCJ1c2VyTmFtZSI6IkhvbmdHaWxEb25nIn0.4lkjYduo8iwv4AcKH96MpTnk8d7HRhi_p1xlnvZts8A
+      opentracing:
+        jaeger:
+          endpoint: localhost:6832
+          service_name: spider grpc client for tumblebug
+          sample_rate: 1

--- a/helm-chart/install/kubernetes/charts/cb-tumblebug/files/conf/log_conf.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-tumblebug/files/conf/log_conf.yaml
@@ -1,0 +1,18 @@
+#### Config for CB-Log Lib. ####
+
+cblog:
+  ## true | false
+  loopcheck: true # This temp method for development is busy wait. cf) cblogger.go:levelSetupLoop().
+
+  ## debug | info | warn | error
+  loglevel: error # If loopcheck is true, You can set this online.
+
+  ## true | false
+  logfile: false 
+
+## Config for File Output ##
+logfileinfo:
+  filename: ./log/cblogs.log
+  maxsize: 10 # megabytes
+  maxbackups: 50
+  maxage: 31 # days

--- a/helm-chart/install/kubernetes/charts/cb-tumblebug/files/conf/store_conf.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-tumblebug/files/conf/store_conf.yaml
@@ -1,0 +1,15 @@
+#### Config for CB-Store ####
+
+# server type: NUTSDB | ETCD
+# NUTSDB: embedded Key-Value Store on Local Filesystem
+storetype: NUTSDB
+#storetype: ETCD
+
+nutsdb:
+  dbpath: "$CBSTORE_ROOT/meta_db/dat"
+  segmentsize: 1048576  # 1048576 1024*1024 (1MB)
+  #segmentsize: 10485760  # 10485760 10*1024*1024 (10MB)
+
+etcd:
+  # etcd server, when ETCD typpe
+  etcdserverport: "cb-etcd:2379"

--- a/helm-chart/install/kubernetes/charts/cb-tumblebug/templates/configmap.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-tumblebug/templates/configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cb-tumblebug.fullname" . }}-config
+  labels:
+    {{- include "cb-tumblebug.labels" .  | nindent 4 }}
+data:
+  grpc_conf.yaml: |-
+    {{ range .Files.Lines "files/conf/grpc_conf.yaml" }}
+    {{ . }}
+    {{ end }}
+  log_conf.yaml: |-
+    {{ range .Files.Lines "files/conf/log_conf.yaml" }}
+    {{ . }}
+    {{ end }}
+  store_conf.yaml: |-
+    {{ range .Files.Lines "files/conf/store_conf.yaml" }}
+    {{ . }}
+    {{ end }}

--- a/helm-chart/install/kubernetes/charts/cb-tumblebug/templates/deployment.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-tumblebug/templates/deployment.yaml
@@ -46,10 +46,15 @@ spec:
           volumeMounts:
           - name: {{ template "cb-tumblebug.fullname" . }}
             mountPath: /app/meta_db
+          - name: config-volume
+            mountPath: {{ .Values.tumblebug.rootPath }}/conf
       volumes:
       - name: {{ template "cb-tumblebug.fullname" . }} #cb-tumblebug-persistent-storage
         persistentVolumeClaim:
           claimName: {{ template "cb-tumblebug.fullname" . }}
+      - name: config-volume
+        configMap:
+          name: {{ include "cb-tumblebug.fullname" . }}-config
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/install/kubernetes/charts/cb-tumblebug/values.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-tumblebug/values.yaml
@@ -1,3 +1,6 @@
+tumblebug:
+  rootPath: "/app"
+
 replicaCount: 1
 
 image:
@@ -5,6 +8,8 @@ image:
   pullPolicy: IfNotPresent
 
 env:
+- name: SPIDER_CALL_METHOD
+  value: "REST"
 - name: SPIDER_REST_URL
   value: "http://cb-restapigw:8000/spider"
 - name: DRAGONFLY_REST_URL


### PR DESCRIPTION
[Config flow]

---

1. `*.yaml` files exist in
   - `helm-chart/install/kubernetes/charts/cb-spider/files/conf/`
   - `helm-chart/install/kubernetes/charts/cb-tumblebug/files/conf/`

---

2. In `helm-chart/install/kubernetes/charts/cb-spider/templates/configmap.yaml`

[Template]
```YAML
apiVersion: v1
kind: ConfigMap
metadata:
  name: {{ include "cb-spider.fullname" . }}-config
  labels:
    {{- include "cb-spider.labels" .  | nindent 4 }}
data:
  grpc_conf.yaml: |-
    {{ range .Files.Lines "files/conf/grpc_conf.yaml" }}
    {{ . }}
    {{ end }}
  log_conf.yaml: |-
    {{ range .Files.Lines "files/conf/log_conf.yaml" }}
    {{ . }}
    {{ end }}
  store_conf.yaml: |-
    {{ range .Files.Lines "files/conf/store_conf.yaml" }}
    {{ . }}
    {{ end }}

```

[Will be rendered like this]
```YAML
# Source: cloud-barista/charts/cb-spider/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: cb-spider-config
  labels:
    helm.sh/chart: cb-spider-0.2.0
    app.kubernetes.io/name: cb-spider
    app.kubernetes.io/instance: cloud-barista
    app.kubernetes.io/version: "v0.2.0-20200804"
    app.kubernetes.io/managed-by: Helm
data:
  grpc_conf.yaml: |-
    
    version: 1
    
    grpc:
    
      spidersrv:
    
        addr: :50251
    
        #reflection: enable
    
        #tls:
    
        #  tls_cert: $CBSPIDER_ROOT/certs/server.crt
    
        #  tls_key: $CBSPIDER_ROOT/certs/server.key
    
        interceptors:
    
          #auth_jwt:
    
          #  jwt_key: your_secret_key
    
          prometheus_metrics:
    
            listen_port: 9092
    
          opentracing:
    
            jaeger:
    
              endpoint: localhost:6831
    
              service_name: spider grpc server
    
              sample_rate: 1
    
    
    
  log_conf.yaml: |-
...
```

---

3. Create a volume that contains virtual YAML files which are generated from K8s ConfigMap object.

In `helm-chart/install/kubernetes/charts/cb-spider/templates/deployment.yaml`
```YAML
      volumes:
      - name: config-volume
        configMap:
          name: {{ include "cb-spider.fullname" . }}-config
```

4. Mount the volume to the `cb-spider` container.

In `helm-chart/install/kubernetes/charts/cb-spider/templates/deployment.yaml`
```YAML
          volumeMounts:
          - name: config-volume
            mountPath: {{ .Values.spider.rootPath }}/conf
```

---

Note:

Changing the content of `helm-chart/install/kubernetes/charts/cb-spider/files/conf/*.yaml`
does not immediately change `*.yaml` in containers.

Changing the K8s ConfigMap object may immediately change `*.yaml` in containers.