### PR TITLE
Open multiple ports for Spider, Tumblebug, and Dragonfly in Helm chart

### DIFF
--- a/helm-chart/install/kubernetes/charts/cb-dragonfly/templates/deployment.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-dragonfly/templates/deployment.yaml
@@ -26,10 +26,10 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
-          ports:
-            - name: http
-              containerPort: 80
-              protocol: TCP
+          #ports:
+          #  - name: http
+          #    containerPort: 80
+          #    protocol: TCP
           # livenessProbe:
           #   httpGet:
           #     path: /

--- a/helm-chart/install/kubernetes/charts/cb-dragonfly/templates/service.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-dragonfly/templates/service.yaml
@@ -10,12 +10,26 @@ spec:
   clusterIP: {{ .Values.service.clusterIP }}
 {{- end }}  
   ports:
-    - port: {{ .Values.service.port }}
+    - port: {{ .Values.service.restPort }}
       protocol: TCP
-      name: http
+      name: rest
       targetPort: 9090
-{{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
-      nodePort: {{ .Values.service.nodePort }}
+{{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.restNodePort))) }}
+      nodePort: {{ .Values.service.restNodePort }}
+{{- end }}
+    - port: {{ .Values.service.grpcPort }}
+      protocol: TCP
+      name: grpc
+      targetPort: 50254
+{{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.grpcNodePort))) }}
+      nodePort: {{ .Values.service.grpcNodePort }}
+{{- end }}
+    - port: {{ .Values.service.monitorPort }}
+      protocol: UDP
+      name: monitor
+      targetPort: 8094
+{{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.monitorNodePort))) }}
+      nodePort: {{ .Values.service.monitorNodePort }}
 {{- end }}
   selector:
     {{- include "cb-dragonfly.selectorLabels" . | nindent 4 }}

--- a/helm-chart/install/kubernetes/charts/cb-dragonfly/values.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-dragonfly/values.yaml
@@ -18,6 +18,8 @@ etcd:
   readinessProbe:
     enabled: true
   allowNoneAuthentication: true
+  volumePermissions:
+    enabled: true
 
 ## cb-dragonfly custom variables
 dragonfly:
@@ -52,7 +54,9 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 9090
+  restPort: 9090
+  grpcPort: 50254
+  monitorPort: 8094
 
 ingress:
   enabled: false

--- a/helm-chart/install/kubernetes/charts/cb-restapigw/templates/deployment.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-restapigw/templates/deployment.yaml
@@ -27,10 +27,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          ports:
-            - name: http
-              containerPort: 80
-              protocol: TCP
+          #ports:
+          #  - name: http
+          #    containerPort: 80
+          #    protocol: TCP
           # livenessProbe:
           #   httpGet:
           #     path: /

--- a/helm-chart/install/kubernetes/charts/cb-spider/templates/deployment.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-spider/templates/deployment.yaml
@@ -27,10 +27,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          ports:
-            - name: http
-              containerPort: 80
-              protocol: TCP
+          #ports:
+          #  - name: http
+          #    containerPort: 80
+          #    protocol: TCP
           env:
             {{- toYaml .Values.env | nindent 12 }}
           # livenessProbe:

--- a/helm-chart/install/kubernetes/charts/cb-spider/templates/service.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-spider/templates/service.yaml
@@ -10,12 +10,19 @@ spec:
   clusterIP: {{ .Values.service.clusterIP }}
 {{- end }}  
   ports:
-    - port: {{ .Values.service.port }}
+    - port: {{ .Values.service.restPort }}
       protocol: TCP
-      name: http
+      name: rest
       targetPort: 1024
-{{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
-      nodePort: {{ .Values.service.nodePort }}
+{{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.restNodePort))) }}
+      nodePort: {{ .Values.service.restNodePort }}
+{{- end }}
+    - port: {{ .Values.service.grpcPort }}
+      protocol: TCP
+      name: grpc
+      targetPort: 50251
+{{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.grpcNodePort))) }}
+      nodePort: {{ .Values.service.grpcNodePort }}
 {{- end }}
   selector:
     {{- include "cb-spider.selectorLabels" . | nindent 4 }}

--- a/helm-chart/install/kubernetes/charts/cb-spider/values.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-spider/values.yaml
@@ -29,7 +29,8 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 1024
+  restPort: 1024
+  grpcPort: 50251
 
 ingress:
   enabled: false

--- a/helm-chart/install/kubernetes/charts/cb-tumblebug/templates/deployment.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-tumblebug/templates/deployment.yaml
@@ -27,10 +27,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          ports:
-            - name: http
-              containerPort: 80
-              protocol: TCP
+          #ports:
+          #  - name: http
+          #    containerPort: 80
+          #    protocol: TCP
           env:
             {{- toYaml .Values.env | nindent 12 }}
           # livenessProbe:

--- a/helm-chart/install/kubernetes/charts/cb-tumblebug/templates/service.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-tumblebug/templates/service.yaml
@@ -10,12 +10,19 @@ spec:
   clusterIP: {{ .Values.service.clusterIP }}
 {{- end }}  
   ports:
-    - port: {{ .Values.service.port }}
+    - port: {{ .Values.service.restPort }}
       protocol: TCP
-      name: http
+      name: rest
       targetPort: 1323
-{{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
-      nodePort: {{ .Values.service.nodePort }}
+{{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.restNodePort))) }}
+      nodePort: {{ .Values.service.restNodePort }}
+{{- end }}
+    - port: {{ .Values.service.grpcPort }}
+      protocol: TCP
+      name: grpc
+      targetPort: 50252
+{{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.grpcNodePort))) }}
+      nodePort: {{ .Values.service.grpcNodePort }}
 {{- end }}
   selector:
     {{- include "cb-tumblebug.selectorLabels" . | nindent 4 }}

--- a/helm-chart/install/kubernetes/charts/cb-tumblebug/values.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-tumblebug/values.yaml
@@ -9,7 +9,7 @@ image:
 
 env:
 - name: SPIDER_CALL_METHOD
-  value: "REST"
+  value: "GRPC"
 - name: SPIDER_REST_URL
   value: "http://cb-restapigw:8000/spider"
 - name: DRAGONFLY_REST_URL
@@ -41,7 +41,8 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 1323
+  restPort: 1323
+  grpcPort: 50252
 
 ingress:
   enabled: false

--- a/helm-chart/install/kubernetes/charts/cb-webtool/templates/deployment.yaml
+++ b/helm-chart/install/kubernetes/charts/cb-webtool/templates/deployment.yaml
@@ -27,10 +27,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          ports:
-            - name: http
-              containerPort: 80
-              protocol: TCP
+          #ports:
+          #  - name: http
+          #    containerPort: 80
+          #    protocol: TCP
           env:
             {{- toYaml .Values.env | nindent 12 }}
           # livenessProbe:

--- a/helm-chart/install/kubernetes/values.yaml
+++ b/helm-chart/install/kubernetes/values.yaml
@@ -1,8 +1,10 @@
 cb-dragonfly:
   enabled : true
   service:
-    nodePort: 30090
     type: NodePort
+    restNodePort: 30090
+    grpcNodePort: 30254
+    monitorNodePort: 30094
   etcd:
     image:
       tag: 3.3.11
@@ -16,8 +18,9 @@ cb-restapigw:
 cb-spider:
   enabled : true
   service:
-    nodePort: 31024
     type: NodePort
+    restNodePort: 31024
+    grpcNodePort: 30251
   persistence:
     enabled: true
     size: 1Gi
@@ -25,8 +28,9 @@ cb-spider:
 cb-tumblebug:
   enabled : true
   service:
-    nodePort: 31323
     type: NodePort
+    restNodePort: 31323
+    grpcNodePort: 30252
   persistence:
     enabled: true
     size: 1Gi


### PR DESCRIPTION
## Ports
- NodePort ports are for expose-and-test for now.

|   | Container & Pod ports | K8s Svc ports | (K8s Ingress ...) |
|---|---|---|---|
| CB-Spider REST | 1024 | ClusterIP: 1024<br>NodePort: 31024 |   |
| CB-Spider gRPC | 50251 | ClusterIP: 50251<br>NodePort: 30251 |   |
| CB-Tumblebug REST | 1323 | ClusterIP: 1323<br>NodePort: 31323 |   |
| CB-Tumblebug gRPC | 50252 | ClusterIP: 50252<br>NodePort: 30252 |   |
| CB-Dragonfly REST | 9090 | ClusterIP: 9090<br>NodePort: 30090 |   |
| CB-Dragonfly gRPC | 50254 (TBD) | ClusterIP: 50254<br>NodePort: 30254 |   |
| CB-Dragonfly monitor | 8094/udp | ClusterIP: 8094<br>NodePort: 30094 |   |
| cb-webtool websvr | 1234 | ClusterIP: 1234<br>NodePort: 31234 |   |
| cb-restapigw endpoint | 8000 | ClusterIP: 8000<br>NodePort: 30080 |   |
| Docker Registry | 5000 | ClusterIP: 5000<br>NodePort: 30500 |   |
|   |   |   |   |

---

```
❯ kubectl get svc -n cloud-barista | grep spider 
cb-spider                       NodePort    10.107.66.232    <none>        1024:31024/TCP,50251:30251/TCP
```

```
❯ kubectl get svc -n cloud-barista | grep tumblebug
cb-tumblebug                    NodePort    10.110.237.43    <none>        1323:31323/TCP,50252:30252/TCP
```

```
❯ kubectl get svc -n cloud-barista | grep dragonfly
cb-dragonfly                    NodePort    10.106.120.7     <none>        9090:30090/TCP,50254:30254/TCP,8094:30094/UDP   14m
cb-dragonfly-etcd               ClusterIP   10.97.125.86     <none>        2379/TCP,2380/TCP                               14m
cb-dragonfly-etcd-headless      ClusterIP   None             <none>        2379/TCP,2380/TCP                               14m
cb-dragonfly-influxdb           ClusterIP   10.109.210.247   <none>        8086/TCP,8088/TCP                               14m
```

---

## Change Tumblebug's Spider-calling method from REST to gRPC
```
❯ ./create-sshKey.sh aws 1 jhseo
####################################################################
## 5. sshKey: Create
####################################################################
[Test for AWS]
{
   "message" : "rpc error: code = Internal desc =  error while calling CCMService.CreateKey() method: aws-us-east-1: does not exist! "
}
```
(Can see that Tumblebug calls Spider with gRPC.)