### PR TITLE
Restore file parameter for Docker-compose

### DIFF
--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -50,13 +50,20 @@ var runCmd = &cobra.Command{
 			var cmdStr string
 			switch common.CB_OPERATOR_MODE {
 			case common.Mode_DockerCompose:
+				if common.FileStr == common.Not_Defined {
+					common.FileStr = common.Default_DockerCompose_Config
+				}
 				cmdStr = "sudo docker-compose -f " + common.FileStr + " up"
 				//fmt.Println(cmdStr)
 				common.SysCall(cmdStr)
 			case common.Mode_Kubernetes:
+				if common.FileStr == common.Not_Defined {
+					common.FileStr = common.Default_Kubernetes_Config
+				}
 				cmdStr = "sudo kubectl create ns " + common.CB_K8s_Namespace
 				common.SysCall(cmdStr)
 				cmdStr = "sudo helm install --namespace " + common.CB_K8s_Namespace + " " + common.CB_Helm_Release_Name + " -f " + common.FileStr + " ../helm-chart --debug"
+				//fmt.Println(cmdStr)
 				common.SysCall(cmdStr)
 			default:
 
@@ -71,7 +78,7 @@ func init() {
 	rootCmd.AddCommand(runCmd)
 
 	pf := runCmd.PersistentFlags()
-	pf.StringVarP(&common.FileStr, "file", "f", "../docker-compose-mode-files/docker-compose.yaml", "Path to Cloud-Barista Docker Compose YAML file")
+	pf.StringVarP(&common.FileStr, "file", "f", common.Not_Defined, "User-defined configuration file")
 	
 	/*
 	switch common.CB_OPERATOR_MODE {

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -71,6 +71,9 @@ func init() {
 	rootCmd.AddCommand(runCmd)
 
 	pf := runCmd.PersistentFlags()
+	pf.StringVarP(&common.FileStr, "file", "f", "../docker-compose-mode-files/docker-compose.yaml", "Path to Cloud-Barista Docker Compose YAML file")
+	
+	/*
 	switch common.CB_OPERATOR_MODE {
 	case common.Mode_DockerCompose:
 		pf.StringVarP(&common.FileStr, "file", "f", "../docker-compose-mode-files/docker-compose.yaml", "Path to Cloud-Barista Docker Compose YAML file")
@@ -79,6 +82,8 @@ func init() {
 	default:
 
 	}
+	*/
+
 	//	cobra.MarkFlagRequired(pf, "file")
 
 	// Here you will define your flags and configuration settings.

--- a/src/common/utility.go
+++ b/src/common/utility.go
@@ -14,6 +14,10 @@ var CB_OPERATOR_MODE string
 const (
 	Mode_DockerCompose   string = "DockerCompose"
 	Mode_Kubernetes      string = "Kubernetes"
+	Default_DockerCompose_Config   	string = "../docker-compose-mode-files/docker-compose.yaml"
+	Default_Kubernetes_Config      	string = "../helm-chart/values.yaml"
+	Not_Defined      				string = "Not_Defined"
+	
 	CB_K8s_Namespace     string = "cloud-barista"
 	CB_Helm_Release_Name string = "cloud-barista"
 )


### PR DESCRIPTION
- 문제
f 옵션이 정상 동작하지 않음.

- 이유 
runCmd의 func init() 내부에 CB_OPERATOR_MODE  를 기준으로 -f 기본 값이 지정되도록 처리되어 있으나,
해당 시점에는 CB_OPERATOR_MODE  값이 정해지지 않으므로, 처리에 오류가 있었음.

```
	switch common.CB_OPERATOR_MODE {
	case common.Mode_DockerCompose:
		pf.StringVarP(&common.FileStr, "file", "f", "../docker-compose-mode-files/docker-compose.yaml", "Path to Cloud-Barista Docker Compose YAML file")
	case common.Mode_Kubernetes:
		pf.StringVarP(&common.FileStr, "file", "f", "../helm-chart/values.yaml", "Path to Cloud-Barista Helm chart file")
	default:
	}
```

- 처리 방식
명령어 실행 시점에 -f 에 의한 config 를 모드에 따라 지정하도록 처리
