### PR TITLE
Update docker-compose.yaml and Helm chart files

### DIFF
--- a/docker-compose-mode-files/conf/cb-spider/calllog_conf.yaml
+++ b/docker-compose-mode-files/conf/cb-spider/calllog_conf.yaml
@@ -1,0 +1,18 @@
+#### Config for Call-Log Lib. ####
+
+calllog:
+  ## true | false
+  loopcheck: false # This temp method for development is busy wait. cf) calllogger.go:levelSetupLoop().
+
+  ## info | error  // The error is like switching off the call-log.
+  loglevel: info # If loopcheck is true, You can set this online.
+
+  ## true | false  // Now false is reserved for the future.
+  logfile: true 
+
+## Config for File Output ##
+logfileinfo:
+  filename: $CBSPIDER_ROOT/log/calllog/calllogs.log
+  maxsize: 20 # megabytes
+  maxbackups: 100
+  maxage: 365 # days

--- a/docker-compose-mode-files/conf/cb-spider/cloudos.yaml
+++ b/docker-compose-mode-files/conf/cb-spider/cloudos.yaml
@@ -1,0 +1,20 @@
+# Cloud Driver Manager of CB-Spider.
+# The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+# The CB-Spider Mission is to connect all the clouds with a single interface.
+#
+#      * Cloud-Barista: https://github.com/cloud-barista
+#
+# by CB-Spider Team, 2020.03.
+
+
+### List of support CloudOS.
+
+cloudos:
+  - AWS
+  - GCP
+  - AZURE
+  - OPENSTACK
+  - CLOUDIT
+  - ALIBABA
+  - DOCKER
+  - CLOUDTWIN

--- a/docker-compose-mode-files/conf/cb-spider/grpc_conf.yaml
+++ b/docker-compose-mode-files/conf/cb-spider/grpc_conf.yaml
@@ -1,7 +1,7 @@
 version: 1
 grpc:
   spidersrv:
-    addr: :50251
+    addr: :2048
     #reflection: enable
     #tls:
     #  tls_cert: $CBSPIDER_ROOT/certs/server.crt

--- a/docker-compose-mode-files/conf/cb-tumblebug/grpc_conf.yaml
+++ b/docker-compose-mode-files/conf/cb-tumblebug/grpc_conf.yaml
@@ -16,9 +16,8 @@ grpc:
           endpoint: localhost:6832
           service_name: tumblebug grpc server
           sample_rate: 1  
-  spidersrv:
-    addr: cb-spider:50251
   spidercli:
+    server_addr: cb-spider:2048
     timeout: 90s
     #tls:
     #  tls_ca: $CBTUMBLEBUG_ROOT/certs/ca.crt

--- a/docker-compose-mode-files/data/grafana/data/plugins/grafana-simple-json-datasource/src/partials/query.editor.html
+++ b/docker-compose-mode-files/data/grafana/data/plugins/grafana-simple-json-datasource/src/partials/query.editor.html
@@ -5,7 +5,7 @@
     </div>
 
     <div class="gf-form" ng-if="ctrl.target.rawQuery">
-      <textarea class="gf-form-input" rows="5" ng-model="ctrl.target.target" spellcheck="false" ng-blur="ctrl.onChangeInternal()" />
+      <textarea class="gf-form-input" rows="5" ng-model="ctrl.target.target" spellcheck="false" ng-blur="ctrl.onChangeInternal()"></textarea>
     </div>
 
     <div ng-if="!ctrl.target.rawQuery">

--- a/docker-compose-mode-files/data/grafana/data/plugins/grafana-simple-json-datasource/src/plugin.json
+++ b/docker-compose-mode-files/data/grafana/data/plugins/grafana-simple-json-datasource/src/plugin.json
@@ -24,8 +24,8 @@
       {"name": "GitHub", "url": "https://github.com/grafana/simple-json-datasource"},
       {"name": "MIT License", "url": "https://github.com/grafana/simple-json-datasource/blob/master/LICENSE"}
     ],
-    "version": "1.4.0",
-    "updated": "2018-06-20"
+    "version": "1.4.1",
+    "updated": "2020-07-31"
   },
 
   "dependencies": {

--- a/docker-compose-mode-files/docker-compose.yaml
+++ b/docker-compose-mode-files/docker-compose.yaml
@@ -70,18 +70,18 @@ services:
     container_name: cb-spider
     ports:
       - "1024:1024"
-      - "50251:50251"
+      - "2048:2048"
     volumes:
       - ./conf/cb-spider:/root/go/src/github.com/cloud-barista/cb-spider/conf
       - ./data/cb-spider/meta_db:/root/go/src/github.com/cloud-barista/cb-spider/meta_db/dat
-#     - ./data/cb-spider/log:/root/go/src/github.com/cloud-barista/cb-spider/log      
+      - ./data/cb-spider/log:/root/go/src/github.com/cloud-barista/cb-spider/log      
     depends_on:
       - cb-restapigw
 
 
   # CB-Tumblebug
   cb-tumblebug:
-    image: cloudbaristaorg/cb-tumblebug:v0.2.0-20201009
+    image: cloudbaristaorg/cb-tumblebug:v0.2.0-20201019
     container_name: cb-tumblebug
     ports:
       - "1323:1323"
@@ -93,7 +93,7 @@ services:
     volumes:
       - ./conf/cb-tumblebug:/app/conf
       - ./data/cb-tumblebug/meta_db:/app/meta_db/dat
-#     - ./data/cb-tumblebug/log:/app/log      
+      - ./data/cb-tumblebug/log:/app/log      
     environment:
       - SPIDER_CALL_METHOD=GRPC
       - SPIDER_REST_URL=http://cb-restapigw:8000/spider
@@ -104,6 +104,7 @@ services:
 #     - DB_DATABASE=cb_tumblebug
 #     - DB_USER=cb_tumblebug
 #     - DB_PASSWORD=cb_tumblebug
+#     - GODEBUG=netdns=go
 
 # cb-tumblebug-mysql:
 #   image: mysql

--- a/helm-chart/charts/cb-spider/files/conf/calllog_conf.yaml
+++ b/helm-chart/charts/cb-spider/files/conf/calllog_conf.yaml
@@ -1,0 +1,18 @@
+#### Config for Call-Log Lib. ####
+
+calllog:
+  ## true | false
+  loopcheck: false # This temp method for development is busy wait. cf) calllogger.go:levelSetupLoop().
+
+  ## info | error  // The error is like switching off the call-log.
+  loglevel: info # If loopcheck is true, You can set this online.
+
+  ## true | false  // Now false is reserved for the future.
+  logfile: true 
+
+## Config for File Output ##
+logfileinfo:
+  filename: $CBSPIDER_ROOT/log/calllog/calllogs.log
+  maxsize: 20 # megabytes
+  maxbackups: 100
+  maxage: 365 # days

--- a/helm-chart/charts/cb-spider/files/conf/cloudos.yaml
+++ b/helm-chart/charts/cb-spider/files/conf/cloudos.yaml
@@ -1,0 +1,20 @@
+# Cloud Driver Manager of CB-Spider.
+# The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+# The CB-Spider Mission is to connect all the clouds with a single interface.
+#
+#      * Cloud-Barista: https://github.com/cloud-barista
+#
+# by CB-Spider Team, 2020.03.
+
+
+### List of support CloudOS.
+
+cloudos:
+  - AWS
+  - GCP
+  - AZURE
+  - OPENSTACK
+  - CLOUDIT
+  - ALIBABA
+  - DOCKER
+  - CLOUDTWIN

--- a/helm-chart/charts/cb-spider/files/conf/grpc_conf.yaml
+++ b/helm-chart/charts/cb-spider/files/conf/grpc_conf.yaml
@@ -1,7 +1,7 @@
 version: 1
 grpc:
   spidersrv:
-    addr: :50251
+    addr: :2048
     #reflection: enable
     #tls:
     #  tls_cert: $CBSPIDER_ROOT/certs/server.crt

--- a/helm-chart/charts/cb-spider/templates/service.yaml
+++ b/helm-chart/charts/cb-spider/templates/service.yaml
@@ -20,7 +20,7 @@ spec:
     - port: {{ .Values.service.grpcPort }}
       protocol: TCP
       name: grpc
-      targetPort: 50251
+      targetPort: 2048
 {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.grpcNodePort))) }}
       nodePort: {{ .Values.service.grpcNodePort }}
 {{- end }}

--- a/helm-chart/charts/cb-spider/values.yaml
+++ b/helm-chart/charts/cb-spider/values.yaml
@@ -30,7 +30,7 @@ securityContext: {}
 service:
   type: ClusterIP
   restPort: 1024
-  grpcPort: 50251
+  grpcPort: 2048
 
 ingress:
   enabled: false

--- a/helm-chart/charts/cb-tumblebug/Chart.yaml
+++ b/helm-chart/charts/cb-tumblebug/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: cb-tumblebug
 type: application
 version: 0.2.0
-appVersion: v0.2.0-20201009
+appVersion: v0.2.0-20201019
 description: CB-Tumblebug Helm chart
 

--- a/helm-chart/charts/cb-tumblebug/files/conf/grpc_conf.yaml
+++ b/helm-chart/charts/cb-tumblebug/files/conf/grpc_conf.yaml
@@ -16,9 +16,8 @@ grpc:
           endpoint: localhost:6832
           service_name: tumblebug grpc server
           sample_rate: 1  
-  spidersrv:
-    addr: cb-spider:50251
   spidercli:
+    server_addr: cb-spider:2048
     timeout: 90s
     #tls:
     #  tls_ca: $CBTUMBLEBUG_ROOT/certs/ca.crt

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -20,7 +20,7 @@ cb-spider:
   service:
     type: NodePort
     restNodePort: 31024
-    grpcNodePort: 30251
+    grpcNodePort: 32048
   persistence:
     enabled: true
     size: 1Gi


### PR DESCRIPTION
- (Resolves #55) Add files
  - `docker-compose-mode-files/conf/cb-spider/calllog_conf.yaml`
  - `docker-compose-mode-files/conf/cb-spider/cloudos.yaml`
  - `helm-chart/charts/cb-spider/files/conf/calllog_conf.yaml`
  - `helm-chart/charts/cb-spider/files/conf/cloudos.yaml`
- (Resolves #57) Update Spider's gRPC port from 50251 (30251 for NodePort) to 2048 (32048 for NodePort)
- Update CB-Tumblebug's container image tag
  - `docker-compose-mode-files/docker-compose.yaml`
  - `helm-chart/charts/cb-tumblebug/Chart.yaml`