### PR TITLE
fix : file  is missing on the helm chart #90

### DIFF
--- a/helm-chart/charts/cb-spider/templates/configmap.yaml
+++ b/helm-chart/charts/cb-spider/templates/configmap.yaml
@@ -17,3 +17,7 @@ data:
     {{ range .Files.Lines "files/conf/store_conf.yaml" }}
     {{ . }}
     {{ end }}
+  calllog_conf.yaml: |-
+    {{ range .Files.Lines "files/conf/calllog_conf.yaml" }}
+    {{ . }}
+    {{ end }}


### PR DESCRIPTION
* CB-Spider configmap 에 "calllog_conf.yaml" 파일 추가 
* #90 