### PR TITLE
Add GitHub workflows 'lint' and 'build'

### DIFF
--- a/.github/workflows/build-on-pull-request.yml
+++ b/.github/workflows/build-on-pull-request.yml
@@ -1,0 +1,53 @@
+# The name of your workflow. GitHub displays the names of your workflows on your repository's actions page.
+# If you omit name, GitHub sets it to the workflow file path relative to the root of the repository.
+name: build-on-pull-request
+
+# This workflow is triggered on pull request
+on:
+  pull_request:
+    branches: [ $default-branch ] #, develop ]
+
+jobs:
+  # Set the job key. The key is displayed as the job name
+  # when a job name is not provided
+  # The job key is “build"
+  build:
+    # Job name is “Build”
+    name: Build
+
+    strategy:
+      matrix:
+        go-version: [ 1.15.x ]
+        os: [ ubuntu-18.04 ] #macos-latest, windows-latest
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      # This action sets up a go environment for use in actions by:
+      #     optionally downloading and caching a version of Go by version and adding to PATH
+      #     registering problem matchers for error output
+      # This step uses GitHub's setup-go: https://github.com/actions/setup-go
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+        id: go
+
+      # This action checks-out your repository under $GITHUB_WORKSPACE, so your workflow can access it.
+      # This step uses GitHub's checkout: https://github.com/actions/checkout
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      # This step installs dependencies
+      #      - name: Get dependencies
+      #        run: |
+      #          go get -v -t -d ./...
+      #          if [ -f Gopkg.toml ]; then
+      #              curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+      #              dep ensure
+      #          fi
+
+      # This step builds source codes
+      - name: Build
+        run: |
+          go build -v ./src
+          

--- a/.github/workflows/lint-on-push.yml
+++ b/.github/workflows/lint-on-push.yml
@@ -32,21 +32,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v2
-      with:
-        # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-        version: v1.29
-        
-        # Add args to skip dirs
-        #args: --skip-dirs mypath
-
-        # Optional: working directory, useful for monorepos
-        # working-directory: somedir
-
-        # Optional: golangci-lint command line arguments.
-        # args: --issues-exit-code=0
-
-        # Optional: show only new issues if it's a pull request. The default value is `false`.
-        # only-new-issues: true
+    - name: Checkout source code
+      uses: actions/checkout@v2
+    
+    - name: Install golangci-lint
+      run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.34.1      
+    
+    - name: Run golangci-lint
+      run: $(go env GOPATH)/bin/golangci-lint run

--- a/.github/workflows/lint-on-push.yml
+++ b/.github/workflows/lint-on-push.yml
@@ -1,0 +1,52 @@
+# The name of your workflow. GitHub displays the names of your workflows on your repository's actions page. 
+# If you omit name, GitHub sets it to the workflow file path relative to the root of the repository.
+name: lint-on-push
+
+# This workflow is triggered on push
+on: 
+  push:
+    # Ignoring branches
+    branches-ignore: 
+      # Push events to branches matching master
+      - 'master'
+      # Push events to branches matching develop
+      #- 'develop'
+      
+    # Ignoring paths
+    paths-ignore:
+      # Push events to mypath/**
+      #- 'mypath/**'    
+
+jobs:
+  # Set the job key. The key is displayed as the job name
+  # when a job name is not provided
+  # The job key is “lint"
+  lint:
+    # Job name is “xxx”
+    name: Lint
+
+    strategy:
+      matrix:
+        go-version: [1.15.x]
+        os: [ubuntu-18.04] #macos-latest, windows-latest
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+        version: v1.29
+        
+        # Add args to skip dirs
+        #args: --skip-dirs mypath
+
+        # Optional: working directory, useful for monorepos
+        # working-directory: somedir
+
+        # Optional: golangci-lint command line arguments.
+        # args: --issues-exit-code=0
+
+        # Optional: show only new issues if it's a pull request. The default value is `false`.
+        # only-new-issues: true

--- a/src/cmd/info.go
+++ b/src/cmd/info.go
@@ -1,18 +1,3 @@
-/*
-Copyright © 2020 NAME HERE <EMAIL ADDRESS>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package cmd
 
 import (
@@ -28,33 +13,34 @@ var infoCmd = &cobra.Command{
 	Short: "Get information of Cloud-Barista System",
 	Long:  `Get information of Cloud-Barista System. Information about containers and container images`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("\n[Get info for Cloud-Barista runtimes]\n")
+		fmt.Println("\n[Get info for Cloud-Barista runtimes]")
+		fmt.Println()
 
 		if common.FileStr == "" {
 			fmt.Println("file is required")
 		} else {
-			common.FileStr = common.GenConfigPath(common.FileStr, common.CB_OPERATOR_MODE)
+			common.FileStr = common.GenConfigPath(common.FileStr, common.CBOperatorMode)
 			var cmdStr string
-			switch common.CB_OPERATOR_MODE {
-			case common.Mode_DockerCompose:
-				common.SysCall_docker_compose_ps()
+			switch common.CBOperatorMode {
+			case common.ModeDockerCompose:
+				common.SysCallDockerComposePs()
 
 				fmt.Println("")
 				fmt.Println("[v]Status of Cloud-Barista runtime images")
 				cmdStr = "sudo COMPOSE_PROJECT_NAME=cloud-barista docker-compose -f " + common.FileStr + " images"
 				//fmt.Println(cmdStr)
 				common.SysCall(cmdStr)
-			case common.Mode_Kubernetes:
+			case common.ModeKubernetes:
 				fmt.Println("[v]Status of Cloud-Barista Helm release")
-				cmdStr = "sudo helm status --namespace " + common.CB_K8s_Namespace + " " + common.CB_Helm_Release_Name
+				cmdStr = "sudo helm status --namespace " + common.CBK8sNamespace + " " + common.CBHelmReleaseName
 				common.SysCall(cmdStr)
 				fmt.Println()
 				fmt.Println("[v]Status of Cloud-Barista pods")
-				cmdStr = "sudo kubectl get pods -n " + common.CB_K8s_Namespace
+				cmdStr = "sudo kubectl get pods -n " + common.CBK8sNamespace
 				common.SysCall(cmdStr)
 				fmt.Println()
 				fmt.Println("[v]Status of Cloud-Barista container images")
-				cmdStr = `sudo kubectl get pods -n ` + common.CB_K8s_Namespace + ` -o jsonpath="{..image}" |\
+				cmdStr = `sudo kubectl get pods -n ` + common.CBK8sNamespace + ` -o jsonpath="{..image}" |\
 				tr -s '[[:space:]]' '\n' |\
 				sort |\
 				uniq`
@@ -70,7 +56,7 @@ func init() {
 	rootCmd.AddCommand(infoCmd)
 
 	pf := infoCmd.PersistentFlags()
-	pf.StringVarP(&common.FileStr, "file", "f", common.Not_Defined, "User-defined configuration file")
+	pf.StringVarP(&common.FileStr, "file", "f", common.NotDefined, "User-defined configuration file")
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command

--- a/src/cmd/pull.go
+++ b/src/cmd/pull.go
@@ -1,18 +1,3 @@
-/*
-Copyright © 2020 NAME HERE <EMAIL ADDRESS>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package cmd
 
 import (
@@ -28,12 +13,13 @@ var pullCmd = &cobra.Command{
 	Short: "Pull images of Cloud-Barista System containers",
 	Long:  `Pull images of Cloud-Barista System containers`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("\n[Pull images of Cloud-Barista System containers]\n")
+		fmt.Println("\n[Pull images of Cloud-Barista System containers]")
+		fmt.Println()
 
 		if common.FileStr == "" {
 			fmt.Println("file is required")
 		} else {
-			common.FileStr = common.GenConfigPath(common.FileStr, common.CB_OPERATOR_MODE)
+			common.FileStr = common.GenConfigPath(common.FileStr, common.CBOperatorMode)
 			/*
 							var configuration mcisReq
 
@@ -61,7 +47,7 @@ func init() {
 	rootCmd.AddCommand(pullCmd)
 
 	pf := pullCmd.PersistentFlags()
-	pf.StringVarP(&common.FileStr, "file", "f", common.Not_Defined, "User-defined configuration file")
+	pf.StringVarP(&common.FileStr, "file", "f", common.NotDefined, "User-defined configuration file")
 	//	cobra.MarkFlagRequired(pf, "file")
 
 	// Here you will define your flags and configuration settings.

--- a/src/cmd/remove.go
+++ b/src/cmd/remove.go
@@ -1,18 +1,3 @@
-/*
-Copyright © 2020 NAME HERE <EMAIL ADDRESS>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package cmd
 
 import (
@@ -29,29 +14,30 @@ var removeCmd = &cobra.Command{
 	Long:  `Stop and Remove Cloud-Barista System. Stop and Remove Cloud-Barista runtimes and related container images and meta-DB if necessary`,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		fmt.Println("\n[Remove Cloud-Barista]\n")
+		fmt.Println("\n[Remove Cloud-Barista]")
+		fmt.Println()
 
 		if common.FileStr == "" {
 			fmt.Println("file is required")
 		} else {
-			common.FileStr = common.GenConfigPath(common.FileStr, common.CB_OPERATOR_MODE)
+			common.FileStr = common.GenConfigPath(common.FileStr, common.CBOperatorMode)
 			var cmdStr string
-			switch common.CB_OPERATOR_MODE {
-			case common.Mode_Kubernetes:
-				cmdStr = "sudo helm uninstall --namespace " + common.CB_K8s_Namespace + " " + common.CB_Helm_Release_Name
+			switch common.CBOperatorMode {
+			case common.ModeKubernetes:
+				cmdStr = "sudo helm uninstall --namespace " + common.CBK8sNamespace + " " + common.CBHelmReleaseName
 				common.SysCall(cmdStr)
 
-				cmdStr = "sudo kubectl delete pvc cb-spider -n " + common.CB_K8s_Namespace
+				cmdStr = "sudo kubectl delete pvc cb-spider -n " + common.CBK8sNamespace
 				common.SysCall(cmdStr)
 
-				cmdStr = "sudo kubectl delete pvc cb-tumblebug -n " + common.CB_K8s_Namespace
+				cmdStr = "sudo kubectl delete pvc cb-tumblebug -n " + common.CBK8sNamespace
 				common.SysCall(cmdStr)
 
-				cmdStr = "sudo kubectl delete pvc data-cb-dragonfly-etcd-0 -n " + common.CB_K8s_Namespace
+				cmdStr = "sudo kubectl delete pvc data-cb-dragonfly-etcd-0 -n " + common.CBK8sNamespace
 				common.SysCall(cmdStr)
 
 				//fallthrough
-			case common.Mode_DockerCompose:
+			case common.ModeDockerCompose:
 				if volFlag && imgFlag {
 					cmdStr = "sudo COMPOSE_PROJECT_NAME=cloud-barista docker-compose -f " + common.FileStr + " down -v --rmi all"
 				} else if volFlag {
@@ -65,7 +51,7 @@ var removeCmd = &cobra.Command{
 				//fmt.Println(cmdStr)
 				common.SysCall(cmdStr)
 
-				common.SysCall_docker_compose_ps()
+				common.SysCallDockerComposePs()
 			default:
 
 			}
@@ -81,7 +67,7 @@ func init() {
 	rootCmd.AddCommand(removeCmd)
 
 	pf := removeCmd.PersistentFlags()
-	pf.StringVarP(&common.FileStr, "file", "f", common.Not_Defined, "User-defined configuration file")
+	pf.StringVarP(&common.FileStr, "file", "f", common.NotDefined, "User-defined configuration file")
 	//	cobra.MarkFlagRequired(pf, "file")
 
 	pf.BoolVarP(&volFlag, "volumes", "v", false, "Remove named volumes declared in the volumes section of the Compose file")

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -1,18 +1,3 @@
-/*
-Copyright © 2020 NAME HERE <EMAIL ADDRESS>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package cmd
 
 import (

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -1,18 +1,3 @@
-/*
-Copyright © 2020 NAME HERE <EMAIL ADDRESS>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package cmd
 
 import (
@@ -28,7 +13,8 @@ var runCmd = &cobra.Command{
 	Short: "Setup and Run Cloud-Barista System",
 	Long:  `Setup and Run Cloud-Barista System`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("\n[Setup and Run Cloud-Barista]\n")
+		fmt.Println("\n[Setup and Run Cloud-Barista]")
+		fmt.Println()
 
 		if common.FileStr == "" {
 			fmt.Println("file is required")
@@ -47,18 +33,18 @@ var runCmd = &cobra.Command{
 
 				common.PrintJsonPretty(configuration)
 			*/
-			common.FileStr = common.GenConfigPath(common.FileStr, common.CB_OPERATOR_MODE)
+			common.FileStr = common.GenConfigPath(common.FileStr, common.CBOperatorMode)
 
 			var cmdStr string
-			switch common.CB_OPERATOR_MODE {
-			case common.Mode_DockerCompose:
+			switch common.CBOperatorMode {
+			case common.ModeDockerCompose:
 				cmdStr = "sudo COMPOSE_PROJECT_NAME=cloud-barista docker-compose -f " + common.FileStr + " up"
 				//fmt.Println(cmdStr)
 				common.SysCall(cmdStr)
-			case common.Mode_Kubernetes:
-				cmdStr = "sudo kubectl create ns " + common.CB_K8s_Namespace
+			case common.ModeKubernetes:
+				cmdStr = "sudo kubectl create ns " + common.CBK8sNamespace
 				common.SysCall(cmdStr)
-				cmdStr = "sudo helm install --namespace " + common.CB_K8s_Namespace + " " + common.CB_Helm_Release_Name + " -f " + common.FileStr + " ../helm-chart --debug"
+				cmdStr = "sudo helm install --namespace " + common.CBK8sNamespace + " " + common.CBHelmReleaseName + " -f " + common.FileStr + " ../helm-chart --debug"
 				//fmt.Println(cmdStr)
 				common.SysCall(cmdStr)
 			default:
@@ -74,13 +60,13 @@ func init() {
 	rootCmd.AddCommand(runCmd)
 
 	pf := runCmd.PersistentFlags()
-	pf.StringVarP(&common.FileStr, "file", "f", common.Not_Defined, "User-defined configuration file")
+	pf.StringVarP(&common.FileStr, "file", "f", common.NotDefined, "User-defined configuration file")
 
 	/*
-		switch common.CB_OPERATOR_MODE {
-		case common.Mode_DockerCompose:
+		switch common.CBOperatorMode {
+		case common.ModeDockerCompose:
 			pf.StringVarP(&common.FileStr, "file", "f", "../docker-compose-mode-files/docker-compose.yaml", "Path to Cloud-Barista Docker Compose YAML file")
-		case common.Mode_Kubernetes:
+		case common.ModeKubernetes:
 			pf.StringVarP(&common.FileStr, "file", "f", "../helm-chart/values.yaml", "Path to Cloud-Barista Helm chart file")
 		default:
 

--- a/src/cmd/stop.go
+++ b/src/cmd/stop.go
@@ -1,18 +1,3 @@
-/*
-Copyright © 2020 NAME HERE <EMAIL ADDRESS>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package cmd
 
 import (
@@ -28,22 +13,23 @@ var stopCmd = &cobra.Command{
 	Short: "Stop Cloud-Barista System",
 	Long:  `Stop Cloud-Barista System`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("\n[Stop Cloud-Barista]\n")
+		fmt.Println("\n[Stop Cloud-Barista]")
+		fmt.Println()
 
 		if common.FileStr == "" {
 			fmt.Println("file is required")
 		} else {
-			common.FileStr = common.GenConfigPath(common.FileStr, common.CB_OPERATOR_MODE)
+			common.FileStr = common.GenConfigPath(common.FileStr, common.CBOperatorMode)
 			var cmdStr string
-			switch common.CB_OPERATOR_MODE {
-			case common.Mode_DockerCompose:
+			switch common.CBOperatorMode {
+			case common.ModeDockerCompose:
 				cmdStr := "sudo COMPOSE_PROJECT_NAME=cloud-barista docker-compose -f " + common.FileStr + " stop"
 				//fmt.Println(cmdStr)
 				common.SysCall(cmdStr)
 
-				common.SysCall_docker_compose_ps()
-			case common.Mode_Kubernetes:
-				cmdStr = "sudo helm uninstall --namespace " + common.CB_K8s_Namespace + " " + common.CB_Helm_Release_Name
+				common.SysCallDockerComposePs()
+			case common.ModeKubernetes:
+				cmdStr = "sudo helm uninstall --namespace " + common.CBK8sNamespace + " " + common.CBHelmReleaseName
 				common.SysCall(cmdStr)
 			default:
 
@@ -57,7 +43,7 @@ func init() {
 	rootCmd.AddCommand(stopCmd)
 
 	pf := stopCmd.PersistentFlags()
-	pf.StringVarP(&common.FileStr, "file", "f", common.Not_Defined, "User-defined configuration file")
+	pf.StringVarP(&common.FileStr, "file", "f", common.NotDefined, "User-defined configuration file")
 	//	cobra.MarkFlagRequired(pf, "file")
 	// Here you will define your flags and configuration settings.
 

--- a/src/common/utility.go
+++ b/src/common/utility.go
@@ -3,25 +3,41 @@ package common
 import (
 	"bufio"
 	"fmt"
+	"os"
 	"os/exec"
 )
 
+// FileStr is a variable that holds path to the docker-compose.yaml.
 var FileStr string
-var CommandStr string
-var TargetStr string
-var CB_OPERATOR_MODE string
 
-const (
-	Mode_DockerCompose           string = "DockerCompose"
-	Mode_Kubernetes              string = "Kubernetes"
-	Default_DockerCompose_Config string = "../docker-compose-mode-files/docker-compose.yaml"
-	Default_Kubernetes_Config    string = "../helm-chart/values.yaml"
-	Not_Defined                  string = "Not_Defined"
+//var CommandStr string
+//var TargetStr string
 
-	CB_K8s_Namespace     string = "cloud-barista"
-	CB_Helm_Release_Name string = "cloud-barista"
-)
+// CBOperatorMode is a variable that holds current cb-operator's mode.
+var CBOperatorMode string
 
+// ModeDockerCompose is a variable that holds string indicating Docker Compose mode.
+var ModeDockerCompose string = "DockerCompose"
+
+// ModeKubernetes is a variable that holds string indicating Kubernetes mode.
+var ModeKubernetes string = "Kubernetes"
+
+// DefaultDockerComposeConfig is a variable that holds path to docker-compose.yaml
+var DefaultDockerComposeConfig string = "../docker-compose-mode-files/docker-compose.yaml"
+
+// DefaultKubernetesConfig is a variable that holds path to helm-chart/values.yaml
+var DefaultKubernetesConfig string = "../helm-chart/values.yaml"
+
+// NotDefined is a variable that holds the string "Not_Defined"
+var NotDefined string = "Not_Defined"
+
+// CBK8sNamespace is a variable that holds the K8s namespace that CB-Operator will use.
+var CBK8sNamespace string = "cloud-barista"
+
+// CBHelmReleaseName is a variable that holds the K8s Helm release name that CB-Operator will use.
+var CBHelmReleaseName string = "cloud-barista"
+
+// SysCall executes user-passed command via system call.
 func SysCall(cmdStr string) {
 	//cmdStr := "sudo docker-compose -f " + common.FileStr + " up"
 	cmd := exec.Command("/bin/sh", "-c", cmdStr)
@@ -29,34 +45,48 @@ func SysCall(cmdStr string) {
 	cmdReader, _ := cmd.StdoutPipe()
 	cmd.Stderr = cmd.Stdout
 
-	cmd.Start()
+	err := cmd.Start()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
 	scanner := bufio.NewScanner(cmdReader)
 	for scanner.Scan() {
 		fmt.Printf("%s\n", scanner.Text())
 	}
-	cmd.Wait()
+
+	err = cmd.Wait()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
 }
 
-func SysCall_docker_compose_ps() {
+// SysCallDockerComposePs executes `docker-compose ps` command via system call.
+func SysCallDockerComposePs() {
 	fmt.Println("\n[v]Status of Cloud-Barista runtimes")
 	cmdStr := "sudo COMPOSE_PROJECT_NAME=cloud-barista docker-compose -f " + FileStr + " ps"
 	SysCall(cmdStr)
 }
 
+// GenConfigPath receives path-to-config-file and cb-operator-mode, and returns path-to-config-file.
 func GenConfigPath(fileStr string, mode string) string {
 	returnStr := fileStr
 	switch mode {
-	case Mode_DockerCompose:
-		if fileStr == Not_Defined {
-			returnStr = Default_DockerCompose_Config
+	case ModeDockerCompose:
+		if fileStr == NotDefined {
+			returnStr = DefaultDockerComposeConfig
 		}
-	case Mode_Kubernetes:
-		if fileStr == Not_Defined {
-			returnStr = Default_Kubernetes_Config
+	case ModeKubernetes:
+		if fileStr == NotDefined {
+			returnStr = DefaultKubernetesConfig
 		}
 	default:
 
 	}
-	fmt.Println("[Config path] " + returnStr + "\n")
+	fmt.Println("[Config path] " + returnStr)
+	fmt.Println()
 	return returnStr
 }

--- a/src/main.go
+++ b/src/main.go
@@ -47,10 +47,10 @@ func scanAndWriteMode() {
 	switch userInput {
 	case 1:
 		fmt.Println("[1: Docker Compose environment (Requires Docker and Docker Compose)] selected.")
-		tempStr = common.Mode_DockerCompose
+		tempStr = common.ModeDockerCompose
 	case 2:
 		fmt.Println("[2: Kubernetes environment (Requires Kubernetes cluster with Helm 3)] selected.")
-		tempStr = common.Mode_Kubernetes
+		tempStr = common.ModeKubernetes
 	default:
 		fmt.Println("You should choose between 1 and 2.")
 		return
@@ -70,14 +70,14 @@ func readMode() string {
 		data, err := ioutil.ReadFile("./CB_OPERATOR_MODE")
 		errCheck(err)
 
-		common.CB_OPERATOR_MODE = string(data)
-		fmt.Println("CB_OPERATOR_MODE: " + common.CB_OPERATOR_MODE)
+		common.CBOperatorMode = string(data)
+		fmt.Println("CB_OPERATOR_MODE: " + common.CBOperatorMode)
 
-		//if common.CB_OPERATOR_MODE == common.DockerCompose || common.CB_OPERATOR_MODE == common.Kubernetes {
-		return common.CB_OPERATOR_MODE
+		//if common.CBOperatorMode == common.DockerCompose || common.CBOperatorMode == common.Kubernetes {
+		return common.CBOperatorMode
 		//}
 
-	} else if os.IsNotExist(err) == true {
+	} else if os.IsNotExist(err) {
 		// path/to/whatever does *not* exist
 		fmt.Println("CB_OPERATOR_MODE file does not exist.")
 		scanAndWriteMode()
@@ -92,23 +92,23 @@ func readMode() string {
 		errCheck(err)
 		return ""
 	}
-	return ""
+	//return ""
 }
 
-//var CB_OPERATOR_MODE string
+//var CBOperatorMode string
 
 func main() {
 
 	mode := readMode()
 
 	switch mode {
-	case common.Mode_DockerCompose:
+	case common.ModeDockerCompose:
 		cmd.Execute()
-	case common.Mode_Kubernetes:
+	case common.ModeKubernetes:
 		cmd.Execute()
 	default:
 		fmt.Println("Invalid CB_OPERATOR_MODE: " + mode)
-		fmt.Println("CB_OPERATOR_MODE should be one of these: " + common.Mode_DockerCompose + ", " + common.Mode_Kubernetes)
+		fmt.Println("CB_OPERATOR_MODE should be one of these: " + common.ModeDockerCompose + ", " + common.ModeKubernetes)
 
 		//fmt.Println("To change CB_OPERATOR_MODE, just delete the CB_OPERATOR_MODE file and re-run the cb-operator.")
 		scanAndWriteMode()


### PR DESCRIPTION
- (이 PR의 Reviewers 로 @hermitkim1 님도 추가하려고 했는데, 추가가 안 되네요.. :( )
![image](https://user-images.githubusercontent.com/46767780/103607328-fa023900-4f5b-11eb-9b9e-a8e63300d2ab.png)

- GitHub workflows 'lint' and 'build' YAML files by @hermitkim1
  - https://github.com/hermitkim1/golang-ci-demo-by-github-actions#lint
- GitHub Lint action 실행 시 내부적으로 `golangci-lint` 가 실행되는데, `--out-format=github-actions` 옵션이 붙어서 실행되어,
GitHub 웹 인터페이스에서는 어느 파일의 어느 라인이 문제인지 알 수가 없습니다. [[링크]](https://github.com/jihoon-seo/cb-operator/runs/1642201369?check_suite_focus=true)
![image](https://user-images.githubusercontent.com/46767780/103607565-8f9dc880-4f5c-11eb-9e6d-3faf43acad7e.png)
  - 시도 1: 개발 VM에 `golint` 를 설치하고 실행하여 표시되는 사항들을 모두 수정했으나, GitHub Lint action 의 `golangci-lint` 는 여전히 에러가 1개 있다고 표시했습니다.
  - 시도 2: 개발 VM에 `golangci-lint` 를 설치하고 실행하여 표시되는 사항들을 모두 수정했더니, GitHub Lint action 도 통과했습니다.
  - 추가 시도: GitHub Lint action 실행 시 `--out-format=github-actions` 옵션을 뺄 수 있을까 했는데, `lint-on-push.yml` 파일에는 해당 구문이 없습니다.
