### PR TITLE
Add changelog-check GitHub Actions workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,34 @@
+# This action requires that any PR targeting the master branch should touch at
+# least one CHANGELOG file. If a CHANGELOG entry is not required, add the "Skip
+# Changelog" label to disable this action.
+
+name: changelog
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - master
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.pull_request.labels.*.name, 'Skip Changelog')"
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check for CHANGELOG changes
+        run: |
+          # Only the latest commit of the feature branch is available
+          # automatically. To diff with the base branch, we need to
+          # fetch that too (and we only need its latest commit).
+          git fetch origin ${{ github.base_ref }} --depth=1
+          if [[ $(git diff --name-only FETCH_HEAD | grep CHANGELOG) ]]
+          then
+            echo "A CHANGELOG was modified. Looks good!"
+          else
+            echo "No CHANGELOG was modified."
+            echo "Please add a CHANGELOG entry, or add the \"Skip Changelog\" label if not required."
+            false
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# dev
+- Add GitHub workflows 'lint' and 'build' (#98)
+- Enable GitHub Actions autoupdate (#99)
+- Add changelog-check GitHub Actions workflow
+
+# v0.3.0-espresso (2020.12.10.)
+
+## ChangeLog
+
+### Feature
+- Add mode-selection feature (#39)
+- Add Helm chart (#40)
+- Add PVC for Cloud-Barista components (#44)
+- Add CB-Ladybug to docker-compose.yaml and Helm chart (#71)
+- Add Prometheus and Grafana to CB Helm chart (#81)
+- Change docker network name (#87)
+
+
 # v0.2.0-cappuccino (2020.06.02.)
 
 ### Changelog


### PR DESCRIPTION
- From [beego/.github/workflows/changelog.yml](https://github.com/beego/beego/blob/develop/.github/workflows/changelog.yml)
  - PR 에 CHANGELOG 업데이트가 포함되어 있지 않으면 false 를 리턴하는 workflow 입니다.
  - 필요 시 `Skip Changelog` 레이블을 달면 회피할 수 있습니다.
  - [beego](https://github.com/beego/beego) repo 는 `master` 브랜치도 있지만 `develop` 브랜치를 default 브랜치로 사용하고 있습니다.
만약 저희도 이런 브랜칭 전략을 사용한다면,
`develop` 브랜치의 CHANGELOG 에는 거의 모든 PR에 대한 CHANGELOG 를 모으고,
나중에 `develop` 브랜치를 `master` 브랜치로 머지할 때 CHANGELOG 를 정리/정제/선별 하는 방안도 있겠습니다.
- 이것을 cb-operator 등에 도입해 보려고 하는 PR 입니다.
  - 이렇게 누적된 CHANGELOG 를, 향후 릴리즈 시 마다 정리/정제/선별하여 기재하면 좋지 않을까 하여.. :)
