### PR TITLE
Remove CB-Dragonfly-related Docker network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Add GitHub workflows 'lint' and 'build' (#98)
 - Enable GitHub Actions autoupdate (#99)
 - Add changelog-check GitHub Actions workflow
+- Remove CB-Dragonfly-related Docker network (#110)
 
 # v0.3.0-espresso (2020.12.10.)
 

--- a/docker-compose-mode-files/conf/cb-dragonfly/log_conf.yaml
+++ b/docker-compose-mode-files/conf/cb-dragonfly/log_conf.yaml
@@ -8,7 +8,7 @@ cblog:
   loglevel: info # If loopcheck is true, You can set this online.
 
   ## true | false
-  logfile: false
+  logfile: true
 
 ## Config for File Output ##
 logfileinfo:

--- a/docker-compose-mode-files/conf/cb-ladybug/log_conf.yaml
+++ b/docker-compose-mode-files/conf/cb-ladybug/log_conf.yaml
@@ -8,7 +8,7 @@ cblog:
   loglevel: error # If loopcheck is true, You can set this online.
 
   ## true | false
-  logfile: false 
+  logfile: true 
 
 ## Config for File Output ##
 logfileinfo:

--- a/docker-compose-mode-files/conf/cb-restapigw/log_conf.yaml
+++ b/docker-compose-mode-files/conf/cb-restapigw/log_conf.yaml
@@ -8,7 +8,7 @@ cblog:
   loglevel: debug # If loopcheck is true, You can set this online.
 
   ## true | false
-  logfile: false
+  logfile: true
 
 ## Config for File Output ##
 logfileinfo:

--- a/docker-compose-mode-files/conf/cb-tumblebug/log_conf.yaml
+++ b/docker-compose-mode-files/conf/cb-tumblebug/log_conf.yaml
@@ -8,7 +8,7 @@ cblog:
   loglevel: error # If loopcheck is true, You can set this online.
 
   ## true | false
-  logfile: false 
+  logfile: true 
 
 ## Config for File Output ##
 logfileinfo:

--- a/docker-compose-mode-files/docker-compose.yaml
+++ b/docker-compose-mode-files/docker-compose.yaml
@@ -66,7 +66,7 @@ services:
 
   # CB-Spider
   cb-spider:
-    image: cloudbaristaorg/cb-spider:v0.3.0-espresso
+    image: cloudbaristaorg/cb-spider:v0.3.2
     container_name: cb-spider
     ports:
       - "1024:1024"
@@ -81,7 +81,7 @@ services:
 
   # CB-Tumblebug
   cb-tumblebug:
-    image: cloudbaristaorg/cb-tumblebug:v0.3.0-espresso
+    image: cloudbaristaorg/cb-tumblebug:0.3.2
     container_name: cb-tumblebug
     ports:
       - "1323:1323"
@@ -195,10 +195,10 @@ services:
 #   restart: always
     security_opt:
       - no-new-privileges
-    networks:
-      cb-dragonfly:
-        aliases:
-          - cb-dragonfly
+#    networks:
+#      cb-dragonfly:
+#        aliases:
+#          - cb-dragonfly
 
   # InfluxDB for CB-Dragonfly
   cb-dragonfly-influxdb:
@@ -214,10 +214,10 @@ services:
       - INFLUXDB_ADMIN_PASSWORD=password
       - INFLUXDB_HTTP_AUTH_ENABLED=true
 #   restart: always
-    networks:
-      cb-dragonfly:
-        aliases:
-          - cb-dragonfly-influxdb
+#    networks:
+#      cb-dragonfly:
+#        aliases:
+#          - cb-dragonfly-influxdb
 
   # zookeeper for CB-Dragonfly
   cb-dragonfly-zookeeper:
@@ -226,10 +226,10 @@ services:
     ports:
       - 2181:2181
 #   restart: always
-    networks:
-      cb-dragonfly:
-        aliases:
-          - cb-dragonfly-zookeeper
+#    networks:
+#      cb-dragonfly:
+#        aliases:
+#          - cb-dragonfly-zookeeper
 
   # kafka for CB-Dragonfly
   cb-dragonfly-kafka:
@@ -249,10 +249,10 @@ services:
     ports:
       - 9092:9092
 #   restart: always
-    networks:
-      cb-dragonfly:
-        aliases:
-          - cb-dragonfly-kafka
+#    networks:
+#      cb-dragonfly:
+#        aliases:
+#          - cb-dragonfly-kafka
 
   # Kapacitor for CB-Dragonfly
   cb-dragonfly-kapacitor:
@@ -268,10 +268,10 @@ services:
     depends_on:
       - cb-dragonfly-influxdb
 #   restart: always
-    networks:
-      cb-dragonfly:
-        aliases:
-          - cb-dragonfly-kapacitor
+#    networks:
+#      cb-dragonfly:
+#        aliases:
+#          - cb-dragonfly-kapacitor
 
   # CB-Webtool
   cb-webtool:
@@ -318,5 +318,5 @@ services:
         #    external:
         #      name: cboperator_default
 
-networks:
-  cb-dragonfly:
+#networks:
+#  cb-dragonfly:

--- a/helm-chart/charts/cb-dragonfly/files/conf/config.yaml
+++ b/helm-chart/charts/cb-dragonfly/files/conf/config.yaml
@@ -17,7 +17,7 @@ kapacitor:
 kafka:
   endpoint_url: cb-dragonfly-kafka
   external_ip: 127.0.0.1
-  deploy_type: "compose"    # deploy environment "compose" => docker-compose or others , "helm" => helm chart on k8s
+  deploy_type: "helm"    # deploy environment "compose" => docker-compose or others , "helm" => helm chart on k8s
   compose_external_port: 9092
   helm_external_port: 32000
   internal_port: 9092

--- a/helm-chart/charts/cb-dragonfly/files/conf/log_conf.yaml
+++ b/helm-chart/charts/cb-dragonfly/files/conf/log_conf.yaml
@@ -8,7 +8,7 @@ cblog:
   loglevel: info # If loopcheck is true, You can set this online.
 
   ## true | false
-  logfile: false
+  logfile: true
 
 ## Config for File Output ##
 logfileinfo:

--- a/helm-chart/charts/cb-ladybug/files/conf/log_conf.yaml
+++ b/helm-chart/charts/cb-ladybug/files/conf/log_conf.yaml
@@ -8,7 +8,7 @@ cblog:
   loglevel: error # If loopcheck is true, You can set this online.
 
   ## true | false
-  logfile: false 
+  logfile: true 
 
 ## Config for File Output ##
 logfileinfo:

--- a/helm-chart/charts/cb-restapigw/files/conf/log_conf.yaml
+++ b/helm-chart/charts/cb-restapigw/files/conf/log_conf.yaml
@@ -8,7 +8,7 @@ cblog:
   loglevel: debug # If loopcheck is true, You can set this online.
 
   ## true | false
-  logfile: false
+  logfile: true
 
 ## Config for File Output ##
 logfileinfo:

--- a/helm-chart/charts/cb-spider/Chart.yaml
+++ b/helm-chart/charts/cb-spider/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cb-spider
 type: application
 version: 0.3.0
-appVersion: v0.3.0-espresso
+appVersion: v0.3.2
 description: CB-Spider Helm chart

--- a/helm-chart/charts/cb-tumblebug/Chart.yaml
+++ b/helm-chart/charts/cb-tumblebug/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: cb-tumblebug
 type: application
 version: 0.3.0
-appVersion: v0.3.0-espresso
+appVersion: 0.3.2
 description: CB-Tumblebug Helm chart
 

--- a/helm-chart/charts/cb-tumblebug/files/conf/log_conf.yaml
+++ b/helm-chart/charts/cb-tumblebug/files/conf/log_conf.yaml
@@ -8,7 +8,7 @@ cblog:
   loglevel: error # If loopcheck is true, You can set this online.
 
   ## true | false
-  logfile: false 
+  logfile: true 
 
 ## Config for File Output ##
 logfileinfo:


### PR DESCRIPTION
- Remove CB-Dragonfly-related Docker network (Resolves #109)
- 각 프레임워크 별 cb-log 설정에 `logfile: false` 로 되어 있는 것을 `logfile: true` 로 변경했습니다.
- `helm-chart/charts/cb-dragonfly/files/conf/config.yaml` 파일의 `kafka:` 섹션에서
`deploy_type: "compose"` 로 되어 있는 것을 `deploy_type: "helm"` 으로 변경했습니다.
(`deploy environment "compose" => docker-compose or others , "helm" => helm chart on k8s`)
- docker-compose.yaml 과 Helm chart 에 있는 프레임워크 컨테이너 이미지 태그를 업데이트 했습니다.
  - CB-Spider: `v0.3.2`
  - CB-Tumblebug: `0.3.2`
  - 관련 thread: https://github.com/cloud-barista/cb-tumblebug/discussions/411
