### PR TITLE
Update conf files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,19 @@
-# dev
-- Add GitHub workflows 'lint' and 'build' (#98)
-- Enable GitHub Actions autoupdate (#99)
-- Add changelog-check GitHub Actions workflow
-- Remove CB-Dragonfly-related Docker network (#110)
+
+# v0.4.0 (Cafe Mocha) (2021.06.30.)
+
+### Feature
+
+- Remove CB-Dragonfly-related Docker network ([#110](https://github.com/cloud-barista/cb-operator/pull/110))
+- Modify PV access mode to ReadWriteOnce ([#127](https://github.com/cloud-barista/cb-operator/pull/127))
+
+
 
 # v0.3.0-espresso (2020.12.10.)
 
 ## ChangeLog
 
 ### Feature
+
 - Add mode-selection feature (#39)
 - Add Helm chart (#40)
 - Add PVC for Cloud-Barista components (#44)
@@ -17,12 +22,15 @@
 - Change docker network name (#87)
 
 
+
 # v0.2.0-cappuccino (2020.06.02.)
 
 ### Changelog
+
 - cb-operator 공개 (Docker Compose 기반)
 
 ### Features
+
 - pull: CB 컨테이너 이미지들을 로컬 이미지 저장소로 다운로드
 - run: CB 컨테이너들을 실행하여 CB 시스템을 구동
 - info: CB 컨테이너들의 상태와 이미지 현황을 표시

--- a/docker-compose-mode-files/conf/cb-ladybug/log_conf.yaml
+++ b/docker-compose-mode-files/conf/cb-ladybug/log_conf.yaml
@@ -12,7 +12,7 @@ cblog:
 
 ## Config for File Output ##
 logfileinfo:
-  filename: $APP_ROOT/log/cblogs.log
+  filename: $APP_ROOT/log/cb-ladybug.log
   maxsize: 10 # megabytes
   maxbackups: 50
   maxage: 31 # days

--- a/docker-compose-mode-files/conf/cb-restapigw/log_conf.yaml
+++ b/docker-compose-mode-files/conf/cb-restapigw/log_conf.yaml
@@ -12,7 +12,7 @@ cblog:
 
 ## Config for File Output ##
 logfileinfo:
-  filename: ./log/cblogs.log
+  filename: ./log/cb-restapigw.log
   maxsize: 10 # megabytes
   maxbackups: 50
   maxage: 31 # days

--- a/docker-compose-mode-files/conf/cb-spider/log_conf.yaml
+++ b/docker-compose-mode-files/conf/cb-spider/log_conf.yaml
@@ -12,7 +12,7 @@ cblog:
 
 ## Config for File Output ##
 logfileinfo:
-  filename: $CBSPIDER_ROOT/log/cblogs.log
+  filename: $CBSPIDER_ROOT/log/cb-spider.log
   maxsize: 10 # megabytes
   maxbackups: 50
   maxage: 31 # days

--- a/docker-compose-mode-files/conf/cb-tumblebug/log_conf.yaml
+++ b/docker-compose-mode-files/conf/cb-tumblebug/log_conf.yaml
@@ -12,7 +12,7 @@ cblog:
 
 ## Config for File Output ##
 logfileinfo:
-  filename: $CBTUMBLEBUG_ROOT/log/cblogs.log
+  filename: $CBTUMBLEBUG_ROOT/log/cb-tumblebug.log
   maxsize: 10 # megabytes
   maxbackups: 50
   maxage: 31 # days

--- a/docker-compose-mode-files/data/grafana/data/plugins/grafana-clock-panel/README.md
+++ b/docker-compose-mode-files/data/grafana/data/plugins/grafana-clock-panel/README.md
@@ -1,4 +1,8 @@
 ## Clock Panel Plugin for Grafana
+[![CircleCI](https://circleci.com/gh/grafana/clock-panel.svg?style=svg)](https://circleci.com/gh/grafana/clock-panel)
+[![David Dependancy Status](https://david-dm.org/grafana/clock-panel.svg)](https://david-dm.org/grafana/clock-panel)
+[![David Dev Dependency Status](https://david-dm.org/grafana/clock-panel/dev-status.svg)](https://david-dm.org/grafana/clock-panel/?type=dev)
+
 The Clock Panel can show the current time or a countdown and updates every second.
 
 Show the time in another office or show a countdown to an important event.
@@ -18,6 +22,10 @@ Show the time in another office or show a countdown to an important event.
 - **Timezone**:
 
   This timezones are supplied by the moment timezone library. Timezone can be set or left to default. Default is moment's guess (whatever that is on your computer). Timezone is also used to calculate countdown deadline in countdown mode.
+
+- **Locale**:
+
+  Locales for date-formatting are supplied by the moment library. The locale can be set or left to default. Default is moment's guess.
 
 - **Countdown Deadline**:
 

--- a/docker-compose-mode-files/docker-compose.yaml
+++ b/docker-compose-mode-files/docker-compose.yaml
@@ -75,7 +75,7 @@ services:
 
   # CB-Spider
   cb-spider:
-    image: cloudbaristaorg/cb-spider:0.3.13
+    image: cloudbaristaorg/cb-spider:0.4.0
     container_name: cb-spider
     ports:
       - "0.0.0.0:1024:1024"
@@ -95,7 +95,7 @@ services:
 
   # CB-Tumblebug
   cb-tumblebug:
-    image: cloudbaristaorg/cb-tumblebug:0.3.7
+    image: cloudbaristaorg/cb-tumblebug:0.4.0
     container_name: cb-tumblebug
     ports:
       - "0.0.0.0:1323:1323"
@@ -117,7 +117,7 @@ services:
       - AUTOCONTROL_DURATION_MS=10000
       - SELF_ENDPOINT=localhost:1323
       - GOLANG_PROTOBUF_REGISTRATION_CONFLICT=ignore
-      - API_DOC_PATH=/app/src/docs/swagger.json
+      - API_DOC_PATH=/app/src/api/rest/docs/swagger.json
       # - DB_URL=cb-tumblebug-mysql:3306
       # - DB_DATABASE=cb_tumblebug
       # - DB_USER=cb_tumblebug
@@ -166,7 +166,7 @@ services:
 
   # CB-Ladybug
   cb-ladybug:
-    image: cloudbaristaorg/cb-ladybug:v0.3.0-espresso
+    image: cloudbaristaorg/cb-ladybug:0.4.0
     container_name: cb-ladybug
     ports:
       - "0.0.0.0:8080:8080"
@@ -190,7 +190,7 @@ services:
 
  # CB-Dragonfly
   cb-dragonfly:
-    image: cloudbaristaorg/cb-dragonfly:0.3.3
+    image: cloudbaristaorg/cb-dragonfly:0.4.0
     container_name: cb-dragonfly
     volumes:
       - ./conf/cb-dragonfly/:/go/src/github.com/cloud-barista/cb-dragonfly/conf/
@@ -293,7 +293,7 @@ services:
 
   # CB-Webtool
   cb-webtool:
-    image: cloudbaristaorg/cb-webtool:v0.3.0-espresso
+    image: cloudbaristaorg/cb-webtool:0.4.0
     container_name: cb-webtool
     ports:
       - "0.0.0.0:1234:1234"
@@ -314,7 +314,7 @@ services:
 
   # CB-RESTAPIGW SERVICE
   cb-restapigw:
-    image: cloudbaristaorg/cb-restapigw:0.3.4
+    image: cloudbaristaorg/cb-restapigw:0.4.0
     container_name: cb-restapigw
     volumes:
       - ./conf/cb-restapigw:/app/conf

--- a/helm-chart/charts/cb-dragonfly/Chart.yaml
+++ b/helm-chart/charts/cb-dragonfly/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: cb-dragonfly
 type: application
-version: 0.3.0
-appVersion: 0.3.3
+version: 0.4.0
+appVersion: 0.4.0
 description: CB-Dragonfly Helm chart
 dependencies:
   - name: influxdb

--- a/helm-chart/charts/cb-dragonfly/files/conf/config.yaml
+++ b/helm-chart/charts/cb-dragonfly/files/conf/config.yaml
@@ -34,10 +34,14 @@ apiServer:
 
 # monitoring interval configuration info
 monitoring:
-  agent_interval: 2                   # agent interval (s)
-  collector_interval: 10             # aggregate interval (s)
-  max_host_count:  10                # maximum host count per collector
-  monitoring_policy: "agentCount"    # "agentCount" => The number of agent, "csp" => csp group
+  agent_interval: 2                                 # agent interval (s)
+  collector_interval: 10                            # aggregate interval (s)
+  max_host_count:  5                                # maximum host count per collector
+  monitoring_policy: "agentCount"                   # "agentCount" => The number of agent, "csp" => csp group
+  default_policy: "push"                            # push, pull
+  puller_interval: 10
+  puller_aggregate_interval: 30
+  aggregate_type: "avg"                             # min, max, avg, last
 
 grpcServer:
   port: 9999

--- a/helm-chart/charts/cb-dragonfly/files/conf/log_conf.yaml
+++ b/helm-chart/charts/cb-dragonfly/files/conf/log_conf.yaml
@@ -12,7 +12,7 @@ cblog:
 
 ## Config for File Output ##
 logfileinfo:
-  filename: $CBMON_ROOT/log/cblogs.log
+  filename: $CBLOG_ROOT/log/cb-dragonfly.log
   maxsize: 10 # megabytes
   maxbackups: 50
   maxage: 31 # days

--- a/helm-chart/charts/cb-ladybug/Chart.yaml
+++ b/helm-chart/charts/cb-ladybug/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cb-ladybug
 type: application
-version: 0.3.0
-appVersion: v0.3.0-espresso
+version: 0.4.0
+appVersion: 0.4.0
 description: CB-Ladybug Helm chart
 

--- a/helm-chart/charts/cb-ladybug/files/conf/log_conf.yaml
+++ b/helm-chart/charts/cb-ladybug/files/conf/log_conf.yaml
@@ -12,7 +12,7 @@ cblog:
 
 ## Config for File Output ##
 logfileinfo:
-  filename: $APP_ROOT/log/cblogs.log
+  filename: $APP_ROOT/log/cb-ladybug.log
   maxsize: 10 # megabytes
   maxbackups: 50
   maxage: 31 # days

--- a/helm-chart/charts/cb-restapigw/Chart.yaml
+++ b/helm-chart/charts/cb-restapigw/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: cb-restapigw
 type: application
-version: 0.3.0
-appVersion: 0.3.4
+version: 0.4.0
+appVersion: 0.4.0
 description: cb-restapigw Helm chart
 
 dependencies:

--- a/helm-chart/charts/cb-restapigw/files/conf/log_conf.yaml
+++ b/helm-chart/charts/cb-restapigw/files/conf/log_conf.yaml
@@ -12,7 +12,7 @@ cblog:
 
 ## Config for File Output ##
 logfileinfo:
-  filename: ./log/cblogs.log
+  filename: ./log/cb-restapigw.log
   maxsize: 10 # megabytes
   maxbackups: 50
   maxage: 31 # days

--- a/helm-chart/charts/cb-spider/Chart.yaml
+++ b/helm-chart/charts/cb-spider/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cb-spider
 type: application
-version: 0.3.0
-appVersion: 0.3.13
+version: 0.4.0
+appVersion: 0.4.0
 description: CB-Spider Helm chart

--- a/helm-chart/charts/cb-spider/files/conf/log_conf.yaml
+++ b/helm-chart/charts/cb-spider/files/conf/log_conf.yaml
@@ -12,7 +12,7 @@ cblog:
 
 ## Config for File Output ##
 logfileinfo:
-  filename: $CBSPIDER_ROOT/log/cblogs.log
+  filename: $CBSPIDER_ROOT/log/cb-spider.log
   maxsize: 10 # megabytes
   maxbackups: 50
   maxage: 31 # days

--- a/helm-chart/charts/cb-tumblebug/Chart.yaml
+++ b/helm-chart/charts/cb-tumblebug/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cb-tumblebug
 type: application
-version: 0.3.0
-appVersion: 0.3.7
+version: 0.4.0
+appVersion: 0.4.0
 description: CB-Tumblebug Helm chart
 

--- a/helm-chart/charts/cb-tumblebug/files/conf/log_conf.yaml
+++ b/helm-chart/charts/cb-tumblebug/files/conf/log_conf.yaml
@@ -12,7 +12,7 @@ cblog:
 
 ## Config for File Output ##
 logfileinfo:
-  filename: $CBTUMBLEBUG_ROOT/log/cblogs.log
+  filename: $CBTUMBLEBUG_ROOT/log/cb-tumblebug.log
   maxsize: 10 # megabytes
   maxbackups: 50
   maxage: 31 # days

--- a/helm-chart/charts/cb-tumblebug/values.yaml
+++ b/helm-chart/charts/cb-tumblebug/values.yaml
@@ -25,7 +25,7 @@ env:
 - name: GOLANG_PROTOBUF_REGISTRATION_CONFLICT
   value: "ignore"
 - name: API_DOC_PATH
-  value: "/app/src/docs/swagger.json"
+  value: "/app/src/api/rest/docs/swagger.json"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm-chart/charts/cb-webtool/Chart.yaml
+++ b/helm-chart/charts/cb-webtool/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cb-webtool
 type: application
-version: 0.3.0
-appVersion: v0.3.0-espresso
+version: 0.4.0
+appVersion: 0.4.0
 description: cb-webtool Helm chart


### PR DESCRIPTION
- #130 (CB-Dragonfly config 파일 수정사항 적용) 변경사항을 Helm chart 에도 반영
- 로그 파일명을 `cblogs.log` 에서 각 프레임워크별로 다르게 설정
- 각 프레임워크별 최신 컨테이너 이미지 태그 반영
  - https://hub.docker.com/r/cloudbaristaorg/cb-spider/tags?page=1&ordering=last_updated
  - https://hub.docker.com/r/cloudbaristaorg/cb-tumblebug/tags?page=1&ordering=last_updated
  - https://hub.docker.com/r/cloudbaristaorg/cb-ladybug/tags?page=1&ordering=last_updated
  - https://hub.docker.com/r/cloudbaristaorg/cb-dragonfly/tags?page=1&ordering=last_updated
  - https://hub.docker.com/r/cloudbaristaorg/cb-webtool/tags?page=1&ordering=last_updated
  - https://hub.docker.com/r/cloudbaristaorg/cb-restapigw/tags?page=1&ordering=last_updated
- https://github.com/cloud-barista/cb-tumblebug/pull/616 (Move Swagger doc files) 으로 인한 변경사항 반영
