### PR TITLE
Add support for GKE

### DIFF
--- a/docker-compose-mode-files/docker-compose-df-only.yaml
+++ b/docker-compose-mode-files/docker-compose-df-only.yaml
@@ -34,8 +34,8 @@ services:
     image: influxdb:1.8-alpine
     container_name: cb-dragonfly-influxdb
     ports:
-      - 28083:8083
       - 28086:8086
+      - 28088:8088
     environment:
       - PRE_CREATE_DB=cbmon
       - INFLUXDB_DB=cbmon

--- a/docker-compose-mode-files/docker-compose.yaml
+++ b/docker-compose-mode-files/docker-compose.yaml
@@ -6,8 +6,8 @@ services:
     image: influxdb:1.8.4
     container_name: cb-restapigw-influxdb
     ports:
-      - "0.0.0.0:8083:8083"
       - "0.0.0.0:8086:8086"
+      - "0.0.0.0:8088:8088"
     env_file:
       - './conf/env.influxdb'
     volumes:
@@ -223,8 +223,8 @@ services:
     image: influxdb:1.8-alpine
     container_name: cb-dragonfly-influxdb
     ports:
-      - 0.0.0.0:28083:8083
       - 0.0.0.0:28086:8086
+      - 0.0.0.0:28088:8088
     environment:
       - PRE_CREATE_DB=cbmon
       - INFLUXDB_DB=cbmon

--- a/helm-chart/charts/cb-dragonfly/files/conf/config.yaml
+++ b/helm-chart/charts/cb-dragonfly/files/conf/config.yaml
@@ -4,7 +4,7 @@
 influxdb:
   endpoint_url: http://cb-dragonfly-influxdb # endpoint for influxDB
   internal_port: 8086
-  external_port: 28086
+  external_port: 8086
   database: cbmon
   user_name: cbmon
   password: password

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -2,10 +2,13 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/cloud-barista/cb-operator/src/common"
 	"github.com/spf13/cobra"
 )
+
+var csp string
 
 // runCmd represents the run command
 var runCmd = &cobra.Command{
@@ -42,12 +45,15 @@ var runCmd = &cobra.Command{
 				//fmt.Println(cmdStr)
 				common.SysCall(cmdStr)
 			case common.ModeKubernetes:
-				// For Kubernetes 1.19 and above (included)
+				// For Kubernetes 1.19 and above
 				cmdStr = "sudo kubectl create ns " + common.CBK8sNamespace + " --dry-run=client -o yaml | kubectl apply -f -"
-				// For Kubernetes 1.18 and below (included)
+				// For Kubernetes 1.18 and below
 				//cmdStr = "sudo kubectl create ns " + common.CBK8sNamespace + " --dry-run -o yaml | kubectl apply -f -"
 				common.SysCall(cmdStr)
 				cmdStr = "sudo helm install --namespace " + common.CBK8sNamespace + " " + common.CBHelmReleaseName + " -f " + common.FileStr + " ../helm-chart --debug"
+				if strings.ToLower(csp) == "gcp" || strings.ToLower(csp) == "gke" {
+					cmdStr += " --set metricServer.enabled=false"
+				}
 				//fmt.Println(cmdStr)
 				common.SysCall(cmdStr)
 			default:
@@ -64,6 +70,7 @@ func init() {
 
 	pf := runCmd.PersistentFlags()
 	pf.StringVarP(&common.FileStr, "file", "f", common.NotDefined, "User-defined configuration file")
+	pf.StringVarP(&csp, "csp", "", common.NotDefined, "Cloud Service Provider / Kind of Managed K8s services")
 
 	/*
 		switch common.CBOperatorMode {


### PR DESCRIPTION
- cb-dragonfly-influxdb, cb-restapigw-influxdb 를 위해 노출했던 8083 포트를 8088 로 수정
  (https://github.com/cloud-barista/cb-dragonfly/issues/71)
- `helm-chart/charts/cb-dragonfly/files/conf/config.yaml` 에서
  `influxdb:` `external_port:` 를 `28086` 에서 `8086` 으로 변경
  (https://github.com/cloud-barista/cb-operator/pull/131#issuecomment-866690901)
- Add support for GKE
  - GCP 웹 콘솔에서 GKE 클러스터를 생성한 뒤
    `./operator run` 실행하면 다음과 같은 에러 발생
  - GKE 클러스터를 만들면 `metrics-server` 파드 및 관련 리소스가 기본적으로 생성되는데
    Cloud-Barista Helm chart 에도 `metrics-server` 파드 및 관련 리소스가 정의되어 있어서
    already exist 에러 발생

> ❯ ./operator run
> CB_OPERATOR_MODE: Kubernetes
> 
> [Setup and Run Cloud-Barista]
> 
> [Config path] ../helm-chart/values.yaml
> 
> namespace/cloud-barista configured
> install.go:159: [debug] Original chart version: ""
> install.go:176: [debug] CHART PATH: /home/jhseo/go/src/github.com/cloud-barista/cb-operator/helm-chart
> 
> coalesce.go:199: warning: destination for resources is a table. Ignoring non-table value <nil>
> coalesce.go:160: warning: skipped value for image: Not a table.
> Error: rendered manifests contain a resource that already exists. Unable to continue with install: ServiceAccount "metrics-server" in namespace "kube-system" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "cloud-barista"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "cloud-barista"

[해결 방법]
- `./operator run` 명령에 `--csp` 플래그를 추가하여
  `./operator run --csp gke` 와 같이 실행하면
  시스템에 `helm install` 명령 실행 시 ` --set metricServer.enabled=false` 인자를 추가하여 실행함
  -> Cloud-Barista Helm chart에 포함되어 있는 `metrics-server` 파드 및 관련 리소스를 추가하지 않음
