### PR TITLE
Update Helm chart and docker-compose.yaml

### DIFF
--- a/docker-compose-mode-files/docker-compose.yaml
+++ b/docker-compose-mode-files/docker-compose.yaml
@@ -75,7 +75,7 @@ services:
 
   # CB-Spider
   cb-spider:
-    image: cloudbaristaorg/cb-spider:0.4.1
+    image: cloudbaristaorg/cb-spider:0.4.6
     container_name: cb-spider
     ports:
       - "0.0.0.0:1024:1024"
@@ -88,14 +88,16 @@ services:
     depends_on:
       - cb-restapigw
     environment:
-      - LOCALHOST=OFF
       - PLUGIN_SW=OFF
       - MEERKAT=OFF
+      # if you leave these values empty, REST Auth will be disabled.
+      - API_USERNAME=
+      - API_PASSWORD=
 
 
   # CB-Tumblebug
   cb-tumblebug:
-    image: cloudbaristaorg/cb-tumblebug:0.4.1
+    image: cloudbaristaorg/cb-tumblebug:0.4.2
     container_name: cb-tumblebug
     ports:
       - "0.0.0.0:1323:1323"
@@ -166,7 +168,7 @@ services:
 
   # CB-Ladybug
   cb-ladybug:
-    image: cloudbaristaorg/cb-ladybug:0.4.1
+    image: cloudbaristaorg/cb-ladybug:0.4.2
     container_name: cb-ladybug
     ports:
       - "0.0.0.0:8080:8080"
@@ -191,7 +193,7 @@ services:
 
  # CB-Dragonfly
   cb-dragonfly:
-    image: cloudbaristaorg/cb-dragonfly:0.4.0
+    image: cloudbaristaorg/cb-dragonfly:0.4.1
     container_name: cb-dragonfly
     volumes:
       - ./conf/cb-dragonfly/:/go/src/github.com/cloud-barista/cb-dragonfly/conf/
@@ -315,7 +317,7 @@ services:
 
   # CB-RESTAPIGW SERVICE
   cb-restapigw:
-    image: cloudbaristaorg/cb-restapigw:0.4.0
+    image: cloudbaristaorg/cb-restapigw:0.4.1
     container_name: cb-restapigw
     volumes:
       - ./conf/cb-restapigw:/app/conf

--- a/helm-chart/charts/cb-dragonfly/Chart.yaml
+++ b/helm-chart/charts/cb-dragonfly/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cb-dragonfly
 type: application
 version: 0.4.0
-appVersion: 0.4.0
+appVersion: 0.4.1
 description: CB-Dragonfly Helm chart
 dependencies:
   - name: influxdb

--- a/helm-chart/charts/cb-dragonfly/files/conf/config.yaml
+++ b/helm-chart/charts/cb-dragonfly/files/conf/config.yaml
@@ -11,7 +11,7 @@ influxdb:
   rpDuration: 4w                                   # retention Policy for DB (h, d, w), min: 1h max: 0s
 
 kapacitor:
-  endpoint_url: http://cb-dragonfly-kapacitor:9092  # endpoint to kapacitor
+  endpoint_url: http://cloud-barista-dragonfly-kapacitor:9092 # endpoint to kapacitor
 
 kafka:
   endpoint_url: cb-dragonfly-kafka

--- a/helm-chart/charts/cb-dragonfly/values.yaml
+++ b/helm-chart/charts/cb-dragonfly/values.yaml
@@ -17,7 +17,7 @@ influxdb:
 
 kapacitor:
   enabled: true
-  nameOverride: "cb-dragonfly-kapacitor"
+  nameOverride: "dragonfly-kapacitor"
   envVars:
     #KAPACITOR_INFLUXDB_0_URLS_0: http://cb-dragonfly-influxdb:8086
     KAPACITOR_INFLUXDB_0_USERNAME: cbmon

--- a/helm-chart/charts/cb-ladybug/Chart.yaml
+++ b/helm-chart/charts/cb-ladybug/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: cb-ladybug
 type: application
 version: 0.4.0
-appVersion: 0.4.1
+appVersion: 0.4.2
 description: CB-Ladybug Helm chart
 

--- a/helm-chart/charts/cb-ladybug/values.yaml
+++ b/helm-chart/charts/cb-ladybug/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 
 image:
   repository: cloudbaristaorg/cb-ladybug
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 env:
 - name: SPIDER_URL

--- a/helm-chart/charts/cb-restapigw/Chart.yaml
+++ b/helm-chart/charts/cb-restapigw/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cb-restapigw
 type: application
 version: 0.4.0
-appVersion: 0.4.0
+appVersion: 0.4.1
 description: cb-restapigw Helm chart
 
 dependencies:

--- a/helm-chart/charts/cb-restapigw/values.yaml
+++ b/helm-chart/charts/cb-restapigw/values.yaml
@@ -43,7 +43,7 @@ replicaCount: 1
 
 image:
   repository: cloudbaristaorg/cb-restapigw
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm-chart/charts/cb-spider/Chart.yaml
+++ b/helm-chart/charts/cb-spider/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cb-spider
 type: application
 version: 0.4.0
-appVersion: 0.4.1
+appVersion: 0.4.6
 description: CB-Spider Helm chart

--- a/helm-chart/charts/cb-spider/templates/configmap.yaml
+++ b/helm-chart/charts/cb-spider/templates/configmap.yaml
@@ -21,3 +21,7 @@ data:
     {{ range .Files.Lines "files/conf/calllog_conf.yaml" }}
     {{ . }}
     {{ end }}
+  cloudos.yaml: |-
+    {{ range .Files.Lines "files/conf/cloudos.yaml" }}
+    {{ . }}
+    {{ end }}

--- a/helm-chart/charts/cb-spider/values.yaml
+++ b/helm-chart/charts/cb-spider/values.yaml
@@ -5,15 +5,21 @@ replicaCount: 1
 
 image:
   repository: cloudbaristaorg/cb-spider
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 env:
-- name: LOCALHOST
-  value: "OFF"
+#- name: SERVER_ADDRESS
+#  value: ""
+- name: SERVICE_ADDRESS
+  value: "192.168.1.6:31024"
 - name: PLUGIN_SW
   value: "OFF"
 - name: MEERKAT
   value: "OFF"
+- name: API_USERNAME
+  value: ""
+- name: API_PASSWORD
+  value: ""
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm-chart/charts/cb-tumblebug/Chart.yaml
+++ b/helm-chart/charts/cb-tumblebug/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: cb-tumblebug
 type: application
 version: 0.4.0
-appVersion: 0.4.1
+appVersion: 0.4.2
 description: CB-Tumblebug Helm chart
 

--- a/helm-chart/charts/cb-tumblebug/values.yaml
+++ b/helm-chart/charts/cb-tumblebug/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 
 image:
   repository: cloudbaristaorg/cb-tumblebug
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 env:
 - name: SPIDER_CALL_METHOD

--- a/helm-chart/charts/cb-webtool/values.yaml
+++ b/helm-chart/charts/cb-webtool/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: cloudbaristaorg/cb-webtool
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 env:
   - name: API_GW

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -87,7 +87,7 @@ weave-scope:
 
 # sub-chart : grafana
 grafana:
-  enabled: false
+  enabled: true
   adminPassword: "admin"
   testFramework:
     enabled: false
@@ -124,7 +124,7 @@ grafana:
 
 # sub-chart : prometheus
 prometheus:
-  enabled: false
+  enabled: true
   #fullnameOverride: "cloud-barista-prometheus"
   server:
     name: server
@@ -171,7 +171,7 @@ prometheus:
 
 # sub-chart : metric-server
 metricServer:
-  enabled: false
+  enabled: true
 
 # sub-chart : etcd
 etcd:


### PR DESCRIPTION
- cb-store v0.4.1 반영된 각 FW 릴리즈의 컨테이너 이미지로 업데이트
  - 관련 디스커션: https://github.com/cloud-barista/cb-operator/discussions/144
- CB-Spider ENV 변경사항 반영
  - 관련 이슈: https://github.com/cloud-barista/cb-spider/issues/445
  - 관련 위키: https://github.com/cloud-barista/cb-spider/wiki/CB-Spider-Service-Address-Configuration
- cb-dragonfly-kapacitor Pod/Svc의 name/fullname 변경
  - 관련 커멘트: https://github.com/cloud-barista/cb-operator/pull/140#discussion_r671088138
  - `name`: `cb-dragonfly-kapacitor` -> `dragonfly-kapacitor`
  - `fullname`: `cloud-barista-cb-dragonfly-kapacitor` -> `cloud-barista-dragonfly-kapacitor`
- Helm chart 에서, `pullPolicy:`를 `IfNotPresent`에서 `Always`로 변경 (`appVersion`을 `latest`로 사용하는 경우를 대비)
- Helm chart 에서, prometheus, grafana, metricServer 재활성화
