### PR TITLE
Add initContainers to wait for etcd

### DIFF
--- a/docker-compose-mode-files/conf/cb-ladybug/grpc_conf.yaml
+++ b/docker-compose-mode-files/conf/cb-ladybug/grpc_conf.yaml
@@ -1,0 +1,19 @@
+version: 1
+grpc:
+  ladybugsrv:
+    addr: :50254
+    #reflection: enable
+    #tls:
+    #  tls_cert: $APP_ROOT/certs/server.crt
+    #  tls_key: $APP_ROOT/certs/server.key
+    interceptors:
+      #auth_jwt:
+      #  jwt_key: your_secret_key
+      prometheus_metrics:
+        listen_port: 9095
+      opentracing:
+        jaeger:
+          endpoint: localhost:6834
+          service_name: ladybug grpc server
+          sample_rate: 1
+          

--- a/docker-compose-mode-files/docker-compose.yaml
+++ b/docker-compose-mode-files/docker-compose.yaml
@@ -75,7 +75,7 @@ services:
 
   # CB-Spider
   cb-spider:
-    image: cloudbaristaorg/cb-spider:0.4.6
+    image: cloudbaristaorg/cb-spider:0.4.7
     container_name: cb-spider
     ports:
       - "0.0.0.0:1024:1024"

--- a/helm-chart/charts/cb-dragonfly/templates/deployment.yaml
+++ b/helm-chart/charts/cb-dragonfly/templates/deployment.yaml
@@ -21,6 +21,18 @@ spec:
       serviceAccountName: {{ include "cb-dragonfly.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: wait-for-etcd
+          image: darthcabs/tiny-tools:1
+          args:
+          - /bin/bash
+          - -c
+          - >
+            set -x;
+            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://cloud-barista-etcd:2379/health)" != "200" ]]; do 
+              echo '.'
+              sleep 15;
+            done
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/helm-chart/charts/cb-ladybug/files/conf/grpc_conf.yaml
+++ b/helm-chart/charts/cb-ladybug/files/conf/grpc_conf.yaml
@@ -1,0 +1,19 @@
+version: 1
+grpc:
+  ladybugsrv:
+    addr: :50254
+    #reflection: enable
+    #tls:
+    #  tls_cert: $APP_ROOT/certs/server.crt
+    #  tls_key: $APP_ROOT/certs/server.key
+    interceptors:
+      #auth_jwt:
+      #  jwt_key: your_secret_key
+      prometheus_metrics:
+        listen_port: 9095
+      opentracing:
+        jaeger:
+          endpoint: localhost:6834
+          service_name: ladybug grpc server
+          sample_rate: 1
+          

--- a/helm-chart/charts/cb-ladybug/templates/deployment.yaml
+++ b/helm-chart/charts/cb-ladybug/templates/deployment.yaml
@@ -21,6 +21,18 @@ spec:
       serviceAccountName: {{ include "cb-ladybug.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: wait-for-etcd
+          image: darthcabs/tiny-tools:1
+          args:
+          - /bin/bash
+          - -c
+          - >
+            set -x;
+            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://cloud-barista-etcd:2379/health)" != "200" ]]; do 
+              echo '.'
+              sleep 15;
+            done
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/helm-chart/charts/cb-restapigw/templates/deployment.yaml
+++ b/helm-chart/charts/cb-restapigw/templates/deployment.yaml
@@ -21,6 +21,18 @@ spec:
       serviceAccountName: {{ include "cb-restapigw.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: wait-for-etcd
+          image: darthcabs/tiny-tools:1
+          args:
+          - /bin/bash
+          - -c
+          - >
+            set -x;
+            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://cloud-barista-etcd:2379/health)" != "200" ]]; do 
+              echo '.'
+              sleep 15;
+            done
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/helm-chart/charts/cb-spider/Chart.yaml
+++ b/helm-chart/charts/cb-spider/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cb-spider
 type: application
 version: 0.4.0
-appVersion: 0.4.6
+appVersion: 0.4.7
 description: CB-Spider Helm chart

--- a/helm-chart/charts/cb-spider/templates/deployment.yaml
+++ b/helm-chart/charts/cb-spider/templates/deployment.yaml
@@ -21,6 +21,18 @@ spec:
       serviceAccountName: {{ include "cb-spider.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: wait-for-etcd
+          image: darthcabs/tiny-tools:1
+          args:
+          - /bin/bash
+          - -c
+          - >
+            set -x;
+            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://cloud-barista-etcd:2379/health)" != "200" ]]; do 
+              echo '.'
+              sleep 15;
+            done
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/helm-chart/charts/cb-tumblebug/templates/deployment.yaml
+++ b/helm-chart/charts/cb-tumblebug/templates/deployment.yaml
@@ -21,6 +21,18 @@ spec:
       serviceAccountName: {{ include "cb-tumblebug.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: wait-for-etcd
+          image: darthcabs/tiny-tools:1
+          args:
+          - /bin/bash
+          - -c
+          - >
+            set -x;
+            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://cloud-barista-etcd:2379/health)" != "200" ]]; do 
+              echo '.'
+              sleep 15;
+            done
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -180,4 +180,6 @@ etcd:
     enabled: false
   auth:
     rbac:
-      rootPassword: "cloud-barista!"
+      enabled: false
+      allowNoneAuthentication: true
+      rootPassword: ""


### PR DESCRIPTION
- Add initContainers to wait for etcd
  - Related discussion: #144
  - 적용 대상: etcd를 사용하는 CB FW 전부 (Spider, Tumblebug, Ladybug, Dragonfly, restapigw)
- CB-Ladybug에 추가된 `grpc_conf.yaml` 를 
  Docker Compose files & Helm chart files 에 추가
- CB-Spider container image tag 업데이트
- etcd Helm chart 에 의해 실행되는 etcd의 RBAC Auth를 disable
  - Closes #146
  - cb-store에서 etcd auth 가 아직 구현되지 않았음 
    (https://github.com/cloud-barista/cb-store/issues/21)
