### PR TITLE
Update config files

### DIFF
--- a/docker-compose-mode-files/docker-compose.yaml
+++ b/docker-compose-mode-files/docker-compose.yaml
@@ -75,7 +75,7 @@ services:
 
   # CB-Spider
   cb-spider:
-    image: cloudbaristaorg/cb-spider:0.4.9
+    image: cloudbaristaorg/cb-spider:0.4.18
     container_name: cb-spider
     ports:
       - "0.0.0.0:1024:1024"
@@ -97,7 +97,7 @@ services:
 
   # CB-Tumblebug
   cb-tumblebug:
-    image: cloudbaristaorg/cb-tumblebug:0.4.6
+    image: cloudbaristaorg/cb-tumblebug:0.4.16
     container_name: cb-tumblebug
     ports:
       - "0.0.0.0:1323:1323"
@@ -169,7 +169,7 @@ services:
       - cb-tumblebug
 
   cb-tumblebug-mapui:
-    image: cloudbaristaorg/cb-mapui:0.4.1
+    image: cloudbaristaorg/cb-mapui:0.4.5
     container_name: cb-tumblebug-mapui
     ports:
       - 0.0.0.0:1324:1324
@@ -178,7 +178,7 @@ services:
 
   # CB-MCKS
   cb-mcks:
-    image: cloudbaristaorg/cb-mcks:0.4.3
+    image: cloudbaristaorg/cb-mcks:0.4.4
     container_name: cb-mcks
     ports:
       - "0.0.0.0:1470:1470"

--- a/helm-chart/charts/cb-dragonfly/templates/ingress.yaml
+++ b/helm-chart/charts/cb-dragonfly/templates/ingress.yaml
@@ -1,11 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cb-dragonfly.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+# {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+# {{- else -}}
+# apiVersion: extensions/v1beta1
+# {{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/helm-chart/charts/cb-ladybug/templates/ingress.yaml
+++ b/helm-chart/charts/cb-ladybug/templates/ingress.yaml
@@ -1,11 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cb-ladybug.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+# {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+# {{- else -}}
+# apiVersion: extensions/v1beta1
+# {{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/helm-chart/charts/cb-mcks/Chart.yaml
+++ b/helm-chart/charts/cb-mcks/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: cb-mcks
 type: application
 version: 0.4.0
-appVersion: 0.4.3
+appVersion: 0.4.4
 description: CB-MCKS Helm chart
 

--- a/helm-chart/charts/cb-mcks/templates/ingress.yaml
+++ b/helm-chart/charts/cb-mcks/templates/ingress.yaml
@@ -1,11 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cb-mcks.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+# {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+# {{- else -}}
+# apiVersion: extensions/v1beta1
+# {{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/helm-chart/charts/cb-restapigw-readonly/templates/ingress.yaml
+++ b/helm-chart/charts/cb-restapigw-readonly/templates/ingress.yaml
@@ -1,11 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cb-restapigw.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+# {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+# {{- else -}}
+# apiVersion: extensions/v1beta1
+# {{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/helm-chart/charts/cb-restapigw/templates/ingress.yaml
+++ b/helm-chart/charts/cb-restapigw/templates/ingress.yaml
@@ -1,11 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cb-restapigw.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+# {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+# {{- else -}}
+# apiVersion: extensions/v1beta1
+# {{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/helm-chart/charts/cb-spider/Chart.yaml
+++ b/helm-chart/charts/cb-spider/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cb-spider
 type: application
 version: 0.4.0
-appVersion: 0.4.9
+appVersion: 0.4.18
 description: CB-Spider Helm chart

--- a/helm-chart/charts/cb-spider/templates/ingress.yaml
+++ b/helm-chart/charts/cb-spider/templates/ingress.yaml
@@ -1,11 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cb-spider.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+# {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+# {{- else -}}
+# apiVersion: extensions/v1beta1
+# {{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/helm-chart/charts/cb-tumblebug/Chart.yaml
+++ b/helm-chart/charts/cb-tumblebug/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: cb-tumblebug
 type: application
 version: 0.4.0
-appVersion: 0.4.6
+appVersion: 0.4.16
 description: CB-Tumblebug Helm chart
 

--- a/helm-chart/charts/cb-tumblebug/charts/cb-tumblebug-mapui/Chart.yaml
+++ b/helm-chart/charts/cb-tumblebug/charts/cb-tumblebug-mapui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cb-tumblebug-mapui
 type: application
 version: 0.4.0
-appVersion: 0.4.1
+appVersion: 0.4.5
 description: cb-tumblebug-mapui Helm chart

--- a/helm-chart/charts/cb-tumblebug/charts/cb-tumblebug-mapui/templates/ingress.yaml
+++ b/helm-chart/charts/cb-tumblebug/charts/cb-tumblebug-mapui/templates/ingress.yaml
@@ -1,11 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cb-tumblebug-mapui.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+# {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+# {{- else -}}
+# apiVersion: extensions/v1beta1
+# {{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/helm-chart/charts/cb-tumblebug/templates/ingress.yaml
+++ b/helm-chart/charts/cb-tumblebug/templates/ingress.yaml
@@ -1,11 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cb-tumblebug.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+# {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+# {{- else -}}
+# apiVersion: extensions/v1beta1
+# {{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/helm-chart/charts/cb-webtool/templates/ingress.yaml
+++ b/helm-chart/charts/cb-webtool/templates/ingress.yaml
@@ -1,11 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cb-webtool.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+# {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+# {{- else -}}
+# apiVersion: extensions/v1beta1
+# {{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/helm-chart/templates/ingress/ingress.yaml
+++ b/helm-chart/templates/ingress/ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 ---
-apiVersion: extensions/v1beta1
+# apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: cb-ingress

--- a/helm-chart/templates/metric-server/components.yml
+++ b/helm-chart/templates/metric-server/components.yml
@@ -40,16 +40,16 @@ subjects:
   name: metrics-server
   namespace: kube-system
 ---
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
-  name: v1beta1.metrics.k8s.io
+  name: v1.metrics.k8s.io
 spec:
   service:
     name: metrics-server
     namespace: kube-system
   group: metrics.k8s.io
-  version: v1beta1
+  version: v1
   insecureSkipTLSVerify: true
   groupPriorityMinimum: 100
   versionPriority: 100


### PR DESCRIPTION
- K8s v1.22 에서, `extensions/v1beta1`, `networking.k8s.io/v1beta1` 등의 K8s API가 deprecate 되었습니다. 
  ([관련 링크](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122))
- 이에, `*/v1beta1` API들을 `*/v1` API로 바꾸었습니다.
  - 이 중, 예를 들어 `networking.k8s.io/v1` 은 `v1.19` 부터 제공되는 API 입니다.
    따라서, 이 PR이 적용되면, CB Helm chart의 Required minimum K8s version은 `v1.19` 가 됩니다.
- Update Cloud-Barista container image tags