### PR TITLE
Update CB Helm chart

### DIFF
--- a/helm-chart/charts/cb-spider/templates/horizontalpodautoscaler.yaml
+++ b/helm-chart/charts/cb-spider/templates/horizontalpodautoscaler.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: cb-spider

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -61,7 +61,7 @@ var runCmd = &cobra.Command{
 					cmdStr += " --set cb-restapigw.service.type=LoadBalancer"
 					cmdStr += " --set cb-webtool.service.type=LoadBalancer"
 
-					if strings.ToLower(k8sprovider) == "gke" {
+					if strings.ToLower(k8sprovider) == "gke" || strings.ToLower(k8sprovider) == "aks" {
 						cmdStr += " --set metricServer.enabled=false"
 					}
 

--- a/src/cmd/update.go
+++ b/src/cmd/update.go
@@ -30,7 +30,7 @@ var updateCmd = &cobra.Command{
 
 			case common.ModeKubernetes:
 				cmdStr = fmt.Sprintf("helm upgrade --namespace %s --install %s -f %s ../helm-chart", common.CBK8sNamespace, common.CBHelmReleaseName, common.FileStr)
-				if strings.ToLower(k8sprovider) == "gke" {
+				if strings.ToLower(k8sprovider) == "gke" || strings.ToLower(k8sprovider) == "aks" {
 					cmdStr += " --set metricServer.enabled=false"
 				}
 				//fmt.Println(cmdStr)


### PR DESCRIPTION
- K8s v1.22, v1.23에서도 실행 가능하도록 autoscaling/v2 apiVersion을 autoscaling/v2beta2으로 하향
- AKS에 배포 시 metrics-server 배포하지 않도록 수정 (AKS 클러스터에는 기본적으로 제공됨)